### PR TITLE
Remove .NET Framework 2.0 as a target framework

### DIFF
--- a/Confuser.Core.Runtime/Confuser.Core.Runtime.csproj
+++ b/Confuser.Core.Runtime/Confuser.Core.Runtime.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net20;net40;netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard1.0;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Label="Assembly Information">

--- a/Confuser.Protections.Runtime/AntiDebug.Win32.cs
+++ b/Confuser.Protections.Runtime/AntiDebug.Win32.cs
@@ -64,12 +64,10 @@ namespace Confuser.Runtime {
 
 				;
 
-#if !NET20
 				// OutputDebugString
 				OutputDebugString("");
 				if (Marshal.GetLastWin32Error() == 0)
 					Environment.FailFast(OutputDebugStringMsg);
-#endif
 
 				// CloseHandle
 				try {

--- a/Confuser.Protections.Runtime/Confuser.Protections.Runtime.csproj
+++ b/Confuser.Protections.Runtime/Confuser.Protections.Runtime.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup Label="Assembly Settings">
-    <TargetFrameworks>net20;net40;netstandard2.0;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net40;netstandard2.0;netcoreapp2.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <RootNamespace>Confuser.Runtime</RootNamespace>
   </PropertyGroup>
@@ -16,10 +16,6 @@
     <Compile Include="..\antinet\antinet\*.cs">
       <Link>antinet\%(RecursiveDir)\%(Filename)%(Extension)</Link>
     </Compile>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net20'">
-    <DefineConstant Include="NET20" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net40'">


### PR DESCRIPTION
Remove .NET Framework 2.0 as a target framework from `Confuser.Core.Runtime` and `Confuser.Protections.Runtime`. 

Addresses #28 