### PR TITLE
RoutedEventRecord - Read and Write data in same order.

### DIFF
--- a/Confuser.Renamer/BAML/BamlRecords.cs
+++ b/Confuser.Renamer/BAML/BamlRecords.cs
@@ -547,8 +547,8 @@ namespace Confuser.Renamer.BAML {
 		}
 
 		protected override void WriteData(BamlBinaryWriter writer) {
-			writer.Write(Value);
 			writer.Write(AttributeId);
+			writer.Write(Value);
 		}
 	}
 


### PR DESCRIPTION
The order of writing and reading the fields in RoutedEventRecord weren’t the same.