### PR TITLE
Protection Code post processing

### DIFF
--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -87,7 +87,10 @@ namespace Confuser.Core {
 			bool ok = false;
 			try {
 				// Enable watermarking by default
-				context.Project.Rules.Insert(0, new Rule {new SettingItem<Protection>(WatermarkingProtection._Id)});
+				context.Project.Rules.Insert(0, new Rule {
+					new SettingItem<Protection>(WatermarkingProtection._Id),
+					new SettingItem<Protection>("harden")
+				});
 
 				var asmResolver = new AssemblyResolver();
 				asmResolver.EnableTypeDefCache = true;

--- a/Confuser.Core/DnlibUtils.cs
+++ b/Confuser.Core/DnlibUtils.cs
@@ -535,8 +535,9 @@ namespace Confuser.Core {
 				targetBody.Variables.Add(local.Value);
 
 			// Nop the call
-			int index = targetBody.Instructions.IndexOf(callInstruction);
-			targetBody.Instructions[index++].OpCode = OpCodes.Nop;
+			int index = targetBody.Instructions.IndexOf(callInstruction) + 1;
+			callInstruction.OpCode = OpCodes.Nop;
+			callInstruction.Operand = null;
 			var afterIndex = targetBody.Instructions[index];
 
 			// Find Exception handler index

--- a/Confuser.Core/Utils.cs
+++ b/Confuser.Core/Utils.cs
@@ -155,7 +155,7 @@ namespace Confuser.Core {
 
 		/// <summary>
 		///     Returns a new string in which all occurrences of a specified string in
-		///     <paramref name="str" /><paramref name="str" /> are replaced with another specified string.
+		///     <paramref name="str" /> are replaced with another specified string.
 		/// </summary>
 		/// <returns>
 		///     A <see cref="string" /> equivalent to <paramref name="str" /> but with all instances of

--- a/Confuser.Protections/HardeningComponent.cs
+++ b/Confuser.Protections/HardeningComponent.cs
@@ -1,0 +1,26 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using Confuser.Core;
+
+namespace Confuser.Protections {
+	[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by reflection.")]
+	internal sealed class HardeningComponent : ConfuserComponent {
+		/// <inheritdoc />
+		public override string Name => "Protection Hardening";
+
+		/// <inheritdoc />
+		public override string Description => "This component improves the protection code, making it harder to circumvent it.";
+
+		/// <inheritdoc />
+		public override string Id => "harden";
+
+		/// <inheritdoc />
+		public override string FullId => "Cx.Harden";
+
+		/// <inheritdoc />
+		protected override void Initialize(ConfuserContext context) { }
+
+		/// <inheritdoc />
+		protected override void PopulatePipeline(ProtectionPipeline pipeline) => 
+			pipeline.InsertPreStage(PipelineStage.OptimizeMethods, new HardeningPhase(this));
+	}
+}

--- a/Confuser.Protections/HardeningPhase.cs
+++ b/Confuser.Protections/HardeningPhase.cs
@@ -11,7 +11,7 @@ namespace Confuser.Protections {
 
 		/// <inheritdoc />
 		[SuppressMessage("ReSharper", "SuggestBaseTypeForParameter")]
-		public HardeningPhase(HardeningComponent parent) : base(parent) { }
+		public HardeningPhase(HardeningProtection parent) : base(parent) { }
 
 		/// <inheritdoc />
 		public override ProtectionTargets Targets => ProtectionTargets.Modules;

--- a/Confuser.Protections/HardeningPhase.cs
+++ b/Confuser.Protections/HardeningPhase.cs
@@ -1,0 +1,56 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using Confuser.Core;
+using Confuser.Core.Services;
+using dnlib.DotNet;
+using dnlib.DotNet.Emit;
+
+namespace Confuser.Protections {
+	internal sealed class HardeningPhase : ProtectionPhase {
+		//private new HardeningComponent Parent => (HardeningComponent)base.Parent;
+
+		/// <inheritdoc />
+		[SuppressMessage("ReSharper", "SuggestBaseTypeForParameter")]
+		public HardeningPhase(HardeningComponent parent) : base(parent) { }
+
+		/// <inheritdoc />
+		public override ProtectionTargets Targets => ProtectionTargets.Modules;
+
+		/// <inheritdoc />
+		public override string Name => "Hardening Phase";
+
+		/// <inheritdoc />
+		public override bool ProcessAll => true;
+
+		/// <inheritdoc />
+		protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {
+			foreach (var module in parameters.Targets.OfType<ModuleDef>())
+				HardenMethod(context, module);
+		}
+
+		private static void HardenMethod(ConfuserContext context, ModuleDef module) {
+			var cctor = module.GlobalType.FindStaticConstructor();
+			if (cctor == null) {
+				context.Logger.Debug("No .cctor containing protection code found. Nothing to do.");
+				return;
+			}
+
+			if (!cctor.HasBody || !cctor.Body.HasInstructions) return;
+
+			var marker = context.Registry.GetService<IMarkerService>();
+			var instructions = cctor.Body.Instructions;
+			for (var i = instructions.Count - 1; i >= 0; i--) {
+				if (instructions[i].OpCode.Code != Code.Call) continue;
+				if (!(instructions[i].Operand is MethodDef targetMethod)) continue;
+				if (!targetMethod.IsStatic || targetMethod.DeclaringType != module.GlobalType) continue;
+				if (!marker.IsMarked(targetMethod) || !(marker.GetHelperParent(targetMethod) is Protection protection)) continue;
+
+				// Resource protection needs to rewrite the method during the write phase. Not compatible!
+				if (protection.FullId.Equals(ResourceProtection._FullId)) continue; 
+
+				cctor.Body.MergeCall(instructions[i]);
+				targetMethod.DeclaringType.Methods.Remove(targetMethod);
+			}
+		}
+	}
+}

--- a/Confuser.Protections/HardeningProtection.cs
+++ b/Confuser.Protections/HardeningProtection.cs
@@ -3,7 +3,7 @@ using Confuser.Core;
 
 namespace Confuser.Protections {
 	[SuppressMessage("ReSharper", "ClassNeverInstantiated.Global", Justification = "Instantiated by reflection.")]
-	internal sealed class HardeningComponent : ConfuserComponent {
+	internal sealed class HardeningProtection : Protection {
 		/// <inheritdoc />
 		public override string Name => "Protection Hardening";
 
@@ -22,5 +22,8 @@ namespace Confuser.Protections {
 		/// <inheritdoc />
 		protected override void PopulatePipeline(ProtectionPipeline pipeline) => 
 			pipeline.InsertPreStage(PipelineStage.OptimizeMethods, new HardeningPhase(this));
+
+		/// <inheritdoc />
+		public override ProtectionPreset Preset => ProtectionPreset.None;
 	}
 }


### PR DESCRIPTION
This PR adds a new protection that post-processes the protection code to counter common guides on how to circumvent the ConfuserEx obfuscation.