### PR TITLE
Added missing check to avoid a NRE

### DIFF
--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -57,7 +57,9 @@ namespace Confuser.Renamer {
 							if (!string.IsNullOrEmpty(local.Name))
 								local.Name = service.ObfuscateName(local.Name, mode);
 						}
-						method.Body.PdbMethod.Scope = new PdbScope();
+
+						if (method.Body.HasPdbMethod)
+							method.Body.PdbMethod.Scope = new PdbScope();
 					}
 				}
 


### PR DESCRIPTION
The PdbMethod may not be set at all, while ConfuserEx is instructed to rename the pdb. This did lead to a NRE.

fixes #182 