### PR TITLE
Disable inlining for methods with constants protection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ Thumbs.db
 *.log
 [Bb]in
 [Dd]ebug*/
-*.lib
 *.sbr
 obj/
 [Rr]elease*/

--- a/Confuser.Protections/Constants/ReferenceReplacer.cs
+++ b/Confuser.Protections/Constants/ReferenceReplacer.cs
@@ -12,6 +12,7 @@ namespace Confuser.Protections.Constants {
 	internal class ReferenceReplacer {
 		public static void ReplaceReference(CEContext ctx, ProtectionParameters parameters) {
 			foreach (var entry in ctx.ReferenceRepl) {
+				EnsureNoInlining(entry.Key);
 				if (parameters.GetParameter<bool>(ctx.Context, entry.Key, "cfg"))
 					ReplaceCFG(entry.Key, entry.Value, ctx);
 				else
@@ -28,6 +29,11 @@ namespace Confuser.Protections.Constants {
 				Instruction instr1 = method.Body.Instructions[i + 1];
 				method.Body.Instructions.Insert(i + 1, Instruction.Create(OpCodes.Br_S, instr1));
 			}
+		}
+
+		static void EnsureNoInlining(MethodDef method) {
+			method.ImplAttributes &= ~MethodImplAttributes.AggressiveInlining;
+			method.ImplAttributes |= MethodImplAttributes.NoInlining;
 		}
 
 		struct CFGContext {

--- a/Confuser2.sln
+++ b/Confuser2.sln
@@ -74,9 +74,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "123_InheritCustomAttr", "Te
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "123_InheritCustomAttr.Test", "Tests\123_InheritCustomAttr.Test\123_InheritCustomAttr.Test.csproj", "{DA7DF89C-447D-4C2D-9C75-933037BF245E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "161_DynamicTypeRename", "Tests\161_DynamicTypeRename\161_DynamicTypeRename.csproj", "{034B1C28-96B9-486A-B238-9C651EAA32CA}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "161_DynamicTypeRename", "Tests\161_DynamicTypeRename\161_DynamicTypeRename.csproj", "{034B1C28-96B9-486A-B238-9C651EAA32CA}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "161_DynamicTypeRename.Test", "Tests\161_DynamicTypeRename.Test\161_DynamicTypeRename.Test.csproj", "{2B914EE7-F206-4A83-B435-460D054315BB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "161_DynamicTypeRename.Test", "Tests\161_DynamicTypeRename.Test\161_DynamicTypeRename.Test.csproj", "{2B914EE7-F206-4A83-B435-460D054315BB}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "193_ConstantsInlining", "Tests\193_ConstantsInlining\193_ConstantsInlining.csproj", "{AB2E1440-7EC2-45A2-8CF3-2975DE8A57AD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "193_ConstantsInlining.Lib", "Tests\193_ConstantsInlining.Lib\193_ConstantsInlining.Lib.csproj", "{630BF262-768C-4085-89B1-9FEF7375F442}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "193_ConstantsInlining.Test", "Tests\193_ConstantsInlining.Test\193_ConstantsInlining.Test.csproj", "{E9D90B2A-F563-4A5E-9EFB-B1D6B1E7F8CB}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -204,6 +210,18 @@ Global
 		{2B914EE7-F206-4A83-B435-460D054315BB}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2B914EE7-F206-4A83-B435-460D054315BB}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2B914EE7-F206-4A83-B435-460D054315BB}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AB2E1440-7EC2-45A2-8CF3-2975DE8A57AD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AB2E1440-7EC2-45A2-8CF3-2975DE8A57AD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AB2E1440-7EC2-45A2-8CF3-2975DE8A57AD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AB2E1440-7EC2-45A2-8CF3-2975DE8A57AD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{630BF262-768C-4085-89B1-9FEF7375F442}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{630BF262-768C-4085-89B1-9FEF7375F442}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{630BF262-768C-4085-89B1-9FEF7375F442}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{630BF262-768C-4085-89B1-9FEF7375F442}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E9D90B2A-F563-4A5E-9EFB-B1D6B1E7F8CB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E9D90B2A-F563-4A5E-9EFB-B1D6B1E7F8CB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E9D90B2A-F563-4A5E-9EFB-B1D6B1E7F8CB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E9D90B2A-F563-4A5E-9EFB-B1D6B1E7F8CB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -230,6 +248,9 @@ Global
 		{DA7DF89C-447D-4C2D-9C75-933037BF245E} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{034B1C28-96B9-486A-B238-9C651EAA32CA} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{2B914EE7-F206-4A83-B435-460D054315BB} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{AB2E1440-7EC2-45A2-8CF3-2975DE8A57AD} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{630BF262-768C-4085-89B1-9FEF7375F442} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{E9D90B2A-F563-4A5E-9EFB-B1D6B1E7F8CB} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D937D9E-E04B-4A68-B639-D4260473A388}

--- a/Tests/193_ConstantsInlining.Lib/193_ConstantsInlining.Lib.csproj
+++ b/Tests/193_ConstantsInlining.Lib/193_ConstantsInlining.Lib.csproj
@@ -1,0 +1,17 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <RootNamespace>ConstantsInlining.Lib</RootNamespace>
+  </PropertyGroup>
+
+  <!--
+    Optimize the assembly in all cases, to allow the unit test case to work. 
+    Allows the JIT compiler to inline code. This is required for the unit test.  
+  -->
+  <PropertyGroup Label="Optimize Build always">
+    <Optimize>true</Optimize>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+</Project>

--- a/Tests/193_ConstantsInlining.Lib/ExternalClass.cs
+++ b/Tests/193_ConstantsInlining.Lib/ExternalClass.cs
@@ -1,0 +1,9 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace ConstantsInlining.Lib {
+	public static class ExternalClass {
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static string GetText() => "From External";
+	}
+}

--- a/Tests/193_ConstantsInlining.Test/193_ConstantsInlining.Test.csproj
+++ b/Tests/193_ConstantsInlining.Test/193_ConstantsInlining.Test.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <RootNamespace>ConstantsInlining.Test</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="xunit" Version="2.3.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Confuser.Core\Confuser.Core.csproj" />
+    <ProjectReference Include="..\..\Confuser.Protections\Confuser.Protections.csproj" />
+    <ProjectReference Include="..\193_ConstantsInlining\193_ConstantsInlining.csproj" />
+    <ProjectReference Include="..\193_ConstantsInlining.Lib\193_ConstantsInlining.Lib.csproj" />
+    <ProjectReference Include="..\Confuser.UnitTest\Confuser.UnitTest.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/193_ConstantsInlining.Test/ConstantInliningTest.cs
+++ b/Tests/193_ConstantsInlining.Test/ConstantInliningTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Confuser.Core;
+using Confuser.Core.Project;
+using Confuser.UnitTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ConstantsInlining.Test {
+	public class ConstantInliningTest {
+		private readonly ITestOutputHelper outputHelper;
+
+		public ConstantInliningTest(ITestOutputHelper outputHelper) =>
+			this.outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
+
+		[Fact]
+		[Trait("Category", "Protection")]
+		[Trait("Protection", "constants")]
+		[Trait("Issue", "https://github.com/mkaring/ConfuserEx/issues/193")]
+		public async Task ConstantInlining() {
+			var baseDir = Environment.CurrentDirectory;
+			var outputDir = Path.Combine(baseDir, "testtmp");
+			var files = new[] { "193_ConstantsInlining.exe", "193_ConstantsInlining.Lib.dll" };
+			foreach (var file in files)
+				FileUtilities.ClearOutput(Path.Combine(outputDir, file));
+
+			var proj = new ConfuserProject {
+				BaseDirectory = baseDir,
+				OutputDirectory = outputDir
+			};
+			proj.Rules.Add(new Rule() {
+				new SettingItem<Protection>("constants") {
+					{ "elements", "S" }
+				}
+			});
+
+			proj.AddRange(files.Select(f => new ProjectModule() { Path = Path.Combine(baseDir, f) }));
+
+			var parameters = new ConfuserParameters {
+				Project = proj,
+				Logger = new XunitLogger(outputHelper)
+			};
+
+			await ConfuserEngine.Run(parameters);
+
+			foreach (var file in files) {
+				Assert.True(File.Exists(Path.Combine(outputDir, file)));
+				Assert.NotEqual(
+					FileUtilities.ComputeFileChecksum(Path.Combine(baseDir, file)),
+					FileUtilities.ComputeFileChecksum(Path.Combine(outputDir, file)));
+			}
+
+			var info = new ProcessStartInfo(Path.Combine(outputDir, files[0])) {
+				RedirectStandardOutput = true,
+				UseShellExecute = false
+			};
+			using (var process = Process.Start(info)) {
+				var stdout = process.StandardOutput;
+				Assert.Equal("START", await stdout.ReadLineAsync());
+				Assert.Equal("From External", await stdout.ReadLineAsync());
+				Assert.Equal("END", await stdout.ReadLineAsync());
+				Assert.Empty(await stdout.ReadToEndAsync());
+				Assert.True(process.HasExited);
+				Assert.Equal(42, process.ExitCode);
+			}
+			
+			foreach (var file in files)
+				FileUtilities.ClearOutput(Path.Combine(outputDir, file));
+		}
+	}
+}

--- a/Tests/193_ConstantsInlining/193_ConstantsInlining.csproj
+++ b/Tests/193_ConstantsInlining/193_ConstantsInlining.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net461</TargetFramework>
+    <RootNamespace>ConstantsInlining</RootNamespace>
+  </PropertyGroup>
+
+  <!--
+    Optimize the assembly in all cases, to allow the unit test case to work. 
+    Allows the JIT compiler to inline code. This is required for the unit test.  
+  -->
+  <PropertyGroup Label="Optimize Build always">
+    <Optimize>true</Optimize>
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\193_ConstantsInlining.Lib\193_ConstantsInlining.Lib.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/193_ConstantsInlining/Program.cs
+++ b/Tests/193_ConstantsInlining/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace ConstantsInlining {
+	public class Program {
+		static int Main(string[] args) {
+			Console.WriteLine("START");
+			Console.WriteLine(Lib.ExternalClass.GetText());
+			Console.WriteLine("END");
+			return 42;
+		}
+	}
+}


### PR DESCRIPTION
The inlining for constants protections may cause problems, in case the calling assembly changes due to inlining. This change disables inlining for methods that contain calls to the constants decoder.