### PR TITLE
don't swallow invalid pattern in message

### DIFF
--- a/Confuser.Core/Marker.cs
+++ b/Confuser.Core/Marker.cs
@@ -215,7 +215,7 @@ namespace Confuser.Core {
 					ret.Add(rule, parser.Parse(rule.Pattern));
 				}
 				catch (InvalidPatternException ex) {
-					context.Logger.ErrorFormat("Invalid rule pattern: " + rule.Pattern + ".", ex);
+					context.Logger.ErrorFormat("Invalid rule pattern: " + rule.Pattern + ": {0}", ex.Message);
 					throw new ConfuserException(ex);
 				}
 				foreach (var setting in rule) {


### PR DESCRIPTION
Before that fix the detail it was like this:

> [ERROR] Invalid rule pattern: not is-public() and is-type(serializable): 

Now it is like this:

> [ERROR] Invalid rule pattern: not is-public() and is-type(serializable): Unknown token 'serializable' at position 28.
