### PR TITLE
Fixing generic signature mismatch

### DIFF
--- a/Tests/118_EnhancedStrongName.Test/EnhancedStrongNameTest.cs
+++ b/Tests/118_EnhancedStrongName.Test/EnhancedStrongNameTest.cs
@@ -16,7 +16,6 @@ namespace EnhancedStrongName.Test {
 			await Run("118_EnhancedStrongName.exe",
 				new[] {"My strong key token: 79A18AF4CEA8A9BD", "My signature is valid!"},
 				null,
-				outputHelper,
 				projectModuleAction: projectModule => {
 					projectModule.SNSigKeyPath = Path.Combine(Environment.CurrentDirectory, "SignatureKey.snk");
 					projectModule.SNPubSigKeyPath = Path.Combine(Environment.CurrentDirectory, "SignaturePubKey.snk");

--- a/Tests/123_InheritCustomAttr.Test/InheritCustomAttributeTest.cs
+++ b/Tests/123_InheritCustomAttr.Test/InheritCustomAttributeTest.cs
@@ -23,7 +23,6 @@ namespace _123_InheritCustomAttr.Test {
 				"123_InheritCustomAttr.exe",
 				new[] {"Monday", "43", "1"},
 				new SettingItem<Protection>("rename") {{"mode", renameMode}, {"flatten", flatten ? "True" : "False"}},
-				outputHelper,
 				$"_{renameMode}_{flatten}",
 				l => Assert.False(l.StartsWith("[WARN]"), "Logged line may not start with [WARN]\r\n" + l));
 

--- a/Tests/161_DynamicTypeRename.Test/RenameDynamicMethodTest.cs
+++ b/Tests/161_DynamicTypeRename.Test/RenameDynamicMethodTest.cs
@@ -30,7 +30,6 @@ namespace DynamicTypeRename.Test {
 					{ "mode", renameMode },
 					{ "flatten", flatten.ToString() }
 				},
-				outputHelper,
 				$"_{renameMode}_{flatten}"
 			);
 

--- a/Tests/193_ConstantsInlining.Test/ConstantInliningTest.cs
+++ b/Tests/193_ConstantsInlining.Test/ConstantInliningTest.cs
@@ -16,6 +16,6 @@ namespace ConstantsInlining.Test {
 		public async Task ConstantInlining() =>
 			await Run(new[] {"193_ConstantsInlining.exe", "193_ConstantsInlining.Lib.dll"},
 				new[] {"From External"},
-				new SettingItem<Protection>("constants") {{"elements", "S"}}, outputHelper);
+				new SettingItem<Protection>("constants") {{"elements", "S"}});
 	}
 }

--- a/Tests/78_SignatureMismatch.Test/SignatureMismatchTest.cs
+++ b/Tests/78_SignatureMismatch.Test/SignatureMismatchTest.cs
@@ -21,8 +21,7 @@ namespace SignatureMismatch.Test {
 					"Dictionary count: 1",
 					"[Test1] = Test2"
 				},
-				new SettingItem<Protection>("rename"),
-				outputHelper
+				new SettingItem<Protection>("rename")
 			);
 	}
 }

--- a/Tests/AntiTamper.Test/AntiTamperTest.cs
+++ b/Tests/AntiTamper.Test/AntiTamperTest.cs
@@ -19,7 +19,6 @@ namespace AntiTamper.Test {
 			await Run("AntiTamper.exe",
 				new[] {"This is a test."},
 				new SettingItem<Protection>("anti tamper") {{"mode", antiTamperMode}},
-				outputHelper,
 				"_" + antiTamperMode);
 	}
 }

--- a/Tests/CompressorWithResx.Test/CompressTest.cs
+++ b/Tests/CompressorWithResx.Test/CompressTest.cs
@@ -22,7 +22,6 @@ namespace CompressorWithResx.Test {
 				resourceProtectionMode != "none"
 					? new SettingItem<Protection>("resources") {{"mode", resourceProtectionMode}}
 					: null,
-				outputHelper,
 				$"_{compatKey}_{deriverKey}_{resourceProtectionMode}",
 				packer: new SettingItem<Packer>("compressor") {{"compat", compatKey}, {"key", deriverKey}});
 

--- a/Tests/Confuser.UnitTest/TestBase.cs
+++ b/Tests/Confuser.UnitTest/TestBase.cs
@@ -15,13 +15,13 @@ namespace Confuser.UnitTest {
 			this.outputHelper = outputHelper ?? throw new ArgumentNullException(nameof(outputHelper));
 
 		public async Task Run(string inputFileName, string[] expectedOutput, SettingItem<Protection> protection,
-			ITestOutputHelper outputHelper, string outputDirSuffix = "", Action<string> outputAction = null, SettingItem<Packer> packer = null,
+			string outputDirSuffix = "", Action<string> outputAction = null, SettingItem<Packer> packer = null,
 			Action<ProjectModule> projectModuleAction = null) =>
 
-			await Run(new[] { inputFileName }, expectedOutput, protection, outputHelper, outputDirSuffix, outputAction, packer,
+			await Run(new[] { inputFileName }, expectedOutput, protection, outputDirSuffix, outputAction, packer,
 				projectModuleAction);
 
-		public async Task Run(string[] inputFileNames, string[] expectedOutput, SettingItem<Protection> protection, ITestOutputHelper outputHelper,
+		public async Task Run(string[] inputFileNames, string[] expectedOutput, SettingItem<Protection> protection,
 			string outputDirSuffix = "", Action<string> outputAction = null, SettingItem<Packer> packer = null,
 			Action<ProjectModule> projectModuleAction = null) {
 

--- a/Tests/SignatureMismatch2.Test/SignatureMismatch2Test.cs
+++ b/Tests/SignatureMismatch2.Test/SignatureMismatch2Test.cs
@@ -16,7 +16,7 @@ namespace SignatureMismatch2.Test {
 		public async Task SignatureMismatch2() =>
 			await Run(
 				new [] { "SignatureMismatch2.exe", "SignatureMismatch2Helper.dll" },
-				new [] { "External" },
+				new [] { "External", "External" },
 				new SettingItem<Protection>("rename") { ["renPublic"] = "true" },
 				outputHelper
 			);

--- a/Tests/SignatureMismatch2.Test/SignatureMismatch2Test.cs
+++ b/Tests/SignatureMismatch2.Test/SignatureMismatch2Test.cs
@@ -17,8 +17,7 @@ namespace SignatureMismatch2.Test {
 			await Run(
 				new [] { "SignatureMismatch2.exe", "SignatureMismatch2Helper.dll" },
 				new [] { "External", "External" },
-				new SettingItem<Protection>("rename") { ["renPublic"] = "true" },
-				outputHelper
+				new SettingItem<Protection>("rename") { ["renPublic"] = "true" }
 			);
 	}
 }

--- a/Tests/SignatureMismatch2/Program.cs
+++ b/Tests/SignatureMismatch2/Program.cs
@@ -12,10 +12,19 @@ namespace SignatureMismatch {
 		public void Method(External obj) => Console.WriteLine(obj.Name);
 	}
 
+	public interface IInterface2<Result> {
+		void Method(Result obj);
+	}
+
+	public class Class2 : IInterface2<External> {
+		public void Method(External obj) => Console.WriteLine(obj.Name);
+	}
+
 	public class Program {
 		static int Main(string[] args) {
 			Console.WriteLine("START");
 			new Class().Method(new External());
+			new Class2().Method(new External());
 			Console.WriteLine("END");
 
 			return 42;

--- a/Tests/VisualBasicRenamingResx.Test/RenamingTest.cs
+++ b/Tests/VisualBasicRenamingResx.Test/RenamingTest.cs
@@ -16,7 +16,6 @@ namespace VisualBasicRenamingResx.Test{
 		public async Task ProtectAndExecuteTest() =>
 			await Run("VisualBasicRenamingResx.exe",
 				new[] {"Test (neutral)"},
-				new SettingItem<Protection>("rename"),
-				outputHelper);
+				new SettingItem<Protection>("rename"));
 	}
 }

--- a/Tests/WinFormsRenaming.Test/RenameDataPropertyNameTest.cs
+++ b/Tests/WinFormsRenaming.Test/RenameDataPropertyNameTest.cs
@@ -19,7 +19,6 @@ namespace WinFormsRenaming.Test {
 				"WinFormsRenaming.dll",
 				null,
 				new SettingItem<Protection>("rename"),
-				outputHelper,
 				outputAction: message => Assert.DoesNotContain("Failed to extract binding property name in", message));
 	}
 }

--- a/Tests/WpfRenaming.Test/ProcessWpfTest.cs
+++ b/Tests/WpfRenaming.Test/ProcessWpfTest.cs
@@ -18,8 +18,7 @@ namespace WpfRenaming.Test {
 			await Run(
 				"WpfRenaming.dll",
 				null,
-				null,
-				outputHelper);
+				null);
 
 		[Fact]
 		[Trait("Category", "Protection")]
@@ -29,7 +28,6 @@ namespace WpfRenaming.Test {
 			await Run(
 				"WpfRenaming.dll",
 				null,
-				new SettingItem<Protection>("rename"),
-				outputHelper);
+				new SettingItem<Protection>("rename"));
 	}
 }


### PR DESCRIPTION
This PR extends on #209 and fixes the problem of a generic type reference not being renamed properly in case the target type is part of another module.