### PR TITLE
Minor improvements to the TraceService (#272)

### DIFF
--- a/Confuser.Core/Services/TraceService.cs
+++ b/Confuser.Core/Services/TraceService.cs
@@ -135,7 +135,7 @@ namespace Confuser.Core.Services {
 					currentStack = beforeDepths[i];
 
 				beforeDepths[i] = currentStack;
-				instr.UpdateStack(ref currentStack);
+				instr.UpdateStack(ref currentStack, Method.HasReturnType);
 				afterDepths[i] = currentStack;
 
 				switch (instr.OpCode.FlowControl) {
@@ -202,7 +202,7 @@ namespace Confuser.Core.Services {
 		/// <returns>The indexes of the begin instruction of arguments.</returns>
 		/// <exception cref="InvalidMethodException">The method body is invalid.</exception>
 		public int[] TraceArguments(Instruction instr) {
-			instr.CalculateStackUsage(out _, out int pop); // pop is number of arguments
+			instr.CalculateStackUsage(Method.HasReturnType, out _, out int pop); // pop is number of arguments
 			if (pop == 0)
 				return new int[0];
 
@@ -220,7 +220,7 @@ namespace Confuser.Core.Services {
 				while (index >= 0) {
 					if (BeforeStackDepths[index] == targetStack) {
 						var currentInstr = method.Body.Instructions[index];
-						currentInstr.CalculateStackUsage(out int push, out pop);
+						currentInstr.CalculateStackUsage(Method.HasReturnType, out int push, out pop);
 						if (push == 0 && pop == 0) {
 							// This instruction isn't doing anything to the stack. Could be a nop or some prefix.
 							// Ignore it and move on to the next.
@@ -229,7 +229,7 @@ namespace Confuser.Core.Services {
 							break;
 						} else {
 							var prevInstr = method.Body.Instructions[index - 1];
-							prevInstr.CalculateStackUsage(out push, out _);
+							prevInstr.CalculateStackUsage(Method.HasReturnType, out push, out _);
 							if (push > 0) {
 								// A duplicate instruction is an acceptable start point in case the preceeding instruction
 								// pushes a value.
@@ -272,7 +272,7 @@ namespace Confuser.Core.Services {
 
 				while (index != instrIndex && index < method.Body.Instructions.Count) {
 					Instruction currentInstr = Instructions[index];
-					currentInstr.CalculateStackUsage(out int push, out pop);
+					currentInstr.CalculateStackUsage(Method.HasReturnType, out int push, out pop);
 					if (currentInstr.OpCode.Code == Code.Dup) {
 						// Special case duplicate. This causes the current value on the stack to be duplicated.
 						// To show this behaviour, we'll fetch the last object on the eval stack and add it back twice.

--- a/Confuser.Core/Services/TraceService.cs
+++ b/Confuser.Core/Services/TraceService.cs
@@ -200,11 +200,8 @@ namespace Confuser.Core.Services {
 		/// </summary>
 		/// <param name="instr">The call instruction.</param>
 		/// <returns>The indexes of the begin instruction of arguments.</returns>
-		/// <exception cref="System.ArgumentException">The specified call instruction is invalid.</exception>
 		/// <exception cref="InvalidMethodException">The method body is invalid.</exception>
 		public int[] TraceArguments(Instruction instr) {
-			if (instr.OpCode.Code != Code.Call && instr.OpCode.Code != Code.Callvirt && instr.OpCode.Code != Code.Newobj)
-				throw new ArgumentException("Invalid call instruction.", "instr");
 			instr.CalculateStackUsage(out _, out int pop); // pop is number of arguments
 			if (pop == 0)
 				return new int[0];


### PR DESCRIPTION
Hello, I've done some basic improvements to the TraceService:
* TraceService can now trace other instructions other than call.
* Method return value is used to improve tracing accuracy when a `ret` instruction is present.

This PR addresses some of the proposed changes in https://github.com/mkaring/ConfuserEx/issues/272