### PR TITLE
Using .NET Standard only for real core builds

### DIFF
--- a/Confuser.MSBuild.Tasks/build/Confuser.MSBuild.Tasks.targets
+++ b/Confuser.MSBuild.Tasks/build/Confuser.MSBuild.Tasks.targets
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <ConfuserAssemblyPath Condition="'$(MSBuildRuntimeType)' == 'Full'">$(MSBuildThisFileDirectory)\..\netframework\</ConfuserAssemblyPath>
-    <ConfuserAssemblyPath Condition="'$(ConfuserAssemblyPath)' == ''">$(MSBuildThisFileDirectory)\..\netstandard\</ConfuserAssemblyPath>
+    <ConfuserAssemblyPath Condition="'$(MSBuildRuntimeType)' == 'Core'">$(MSBuildThisFileDirectory)\..\netstandard\</ConfuserAssemblyPath>
+    <ConfuserAssemblyPath Condition="'$(ConfuserAssemblyPath)' == ''">$(MSBuildThisFileDirectory)\..\netframework\</ConfuserAssemblyPath>
   </PropertyGroup>
 
   <UsingTask TaskName="Confuser.MSBuild.Tasks.CreateProjectTask"


### PR DESCRIPTION
This change effects how the mono version of MSBuild resolves the assemblies.

fixes #265