### PR TITLE
Add baseDir config in command.

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -21,6 +21,7 @@ namespace Confuser.CLI {
 				string baseDir = null;
 				List<string> probePaths = new List<string>();
 				List<string> plugins = new List<string>();
+				string namespace_prefix = null;
 				var p = new OptionSet {
 					{
 						"n|nopause", "no pause after finishing protection.",
@@ -40,6 +41,9 @@ namespace Confuser.CLI {
 					}, {
 						"baseDir=", "The base directory of all relative path used in the project document.",
 						value => { baseDir = value; }
+					}, {
+						"namespace_prefix=", "The prefix that will add to the obfuscated namespace",
+						value => { namespace_prefix = value; }
 					}
 				};
 
@@ -124,7 +128,7 @@ namespace Confuser.CLI {
 					proj.Debug = debug;
 					parameters.Project = proj;
 				}
-
+				parameters.namespace_prefix = namespace_prefix;
 				int retVal = RunProject(parameters);
 
 				if (NeedPause() && !noPause) {

--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -18,6 +18,7 @@ namespace Confuser.CLI {
 				bool noPause = false;
 				bool debug = false;
 				string outDir = null;
+				string baseDir = null;
 				List<string> probePaths = new List<string>();
 				List<string> plugins = new List<string>();
 				var p = new OptionSet {
@@ -36,6 +37,9 @@ namespace Confuser.CLI {
 					}, {
 						"debug", "specifies debug symbol generation.",
 						value => { debug = (value != null); }
+					}, {
+						"baseDir=", "The base directory of all relative path used in the project document.",
+						value => { baseDir = value; }
 					}
 				};
 
@@ -60,7 +64,23 @@ namespace Confuser.CLI {
 						var xmlDoc = new XmlDocument();
 						xmlDoc.Load(files[0]);
 						proj.Load(xmlDoc);
-						proj.BaseDirectory = Path.Combine(Path.GetDirectoryName(files[0]), proj.BaseDirectory);
+						foreach (var path in probePaths)
+							proj.ProbePaths.Add(path);
+						foreach (var path in plugins)
+							proj.PluginPaths.Add(path);
+
+						if (baseDir != null && baseDir.Length > 0) {
+							proj.BaseDirectory = Path.Combine(Path.GetDirectoryName(files[0]), baseDir);
+						}
+						else {
+							proj.BaseDirectory = Path.Combine(Path.GetDirectoryName(files[0]), proj.BaseDirectory);
+						}
+
+						if (outDir != null && outDir.Length > 0) {
+							proj.OutputDirectory = outDir;
+						}
+
+						proj.Debug = debug;
 					}
 					catch (Exception ex) {
 						WriteLineWithColor(ConsoleColor.Red, "Failed to load project:");

--- a/Confuser.Core/ConfuserContext.cs
+++ b/Confuser.Core/ConfuserContext.cs
@@ -14,6 +14,8 @@ namespace Confuser.Core {
 		readonly ServiceRegistry registry = new ServiceRegistry();
 		internal CancellationToken token;
 
+		public string namespace_prefix = null;
+
 		/// <summary>
 		///     Gets the logger used for logging events.
 		/// </summary>

--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -174,6 +174,7 @@ namespace Confuser.Core {
 				}
 
 				context.CheckCancellation();
+				context.namespace_prefix = parameters.namespace_prefix;
 
 				//7. Run pipeline
 				RunPipeline(pipeline, context);

--- a/Confuser.Core/ConfuserParameters.cs
+++ b/Confuser.Core/ConfuserParameters.cs
@@ -12,6 +12,8 @@ namespace Confuser.Core {
 		/// <value>The Confuser project.</value>
 		public ConfuserProject Project { get; set; }
 
+		public string namespace_prefix = null;
+
 		/// <summary>
 		///     Gets or sets the logger that used to log the protection process.
 		/// </summary>

--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -80,7 +80,7 @@ namespace Confuser.Renamer {
 						typeDef.Namespace = "";
 					}
 					else {
-						typeDef.Namespace = service.ObfuscateName(typeDef.Namespace, mode);
+						typeDef.Namespace = context.namespace_prefix + service.ObfuscateName(typeDef.Namespace, mode);
 						typeDef.Name = service.ObfuscateName(typeDef.Name, mode);
 					}
 					foreach (var param in typeDef.GenericParameters)


### PR DESCRIPTION
During use, baseDir, outputDir, and probePath are dynamically changing and need to be passed in when calling. This submission allows these parameters to be passed on the command line and take effect correctly.