### PR TITLE
Add the feature to add the prefix to namespace.

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -20,6 +20,7 @@ namespace Confuser.CLI {
 				string outDir = null;
 				List<string> probePaths = new List<string>();
 				List<string> plugins = new List<string>();
+				string namespace_prefix = null;
 				var p = new OptionSet {
 					{
 						"n|nopause", "no pause after finishing protection.",
@@ -36,6 +37,9 @@ namespace Confuser.CLI {
 					}, {
 						"debug", "specifies debug symbol generation.",
 						value => { debug = (value != null); }
+					}, {
+						"namespace_prefix=", "The prefix that will add to the obfuscated namespace",
+						value => { namespace_prefix = value; }
 					}
 				};
 
@@ -104,7 +108,7 @@ namespace Confuser.CLI {
 					proj.Debug = debug;
 					parameters.Project = proj;
 				}
-
+				parameters.namespace_prefix = namespace_prefix;
 				int retVal = RunProject(parameters);
 
 				if (NeedPause() && !noPause) {

--- a/Confuser.Core/ConfuserContext.cs
+++ b/Confuser.Core/ConfuserContext.cs
@@ -14,6 +14,8 @@ namespace Confuser.Core {
 		readonly ServiceRegistry registry = new ServiceRegistry();
 		internal CancellationToken token;
 
+		public string namespace_prefix = null;
+
 		/// <summary>
 		///     Gets the logger used for logging events.
 		/// </summary>

--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -174,6 +174,7 @@ namespace Confuser.Core {
 				}
 
 				context.CheckCancellation();
+				context.namespace_prefix = parameters.namespace_prefix;
 
 				//7. Run pipeline
 				RunPipeline(pipeline, context);

--- a/Confuser.Core/ConfuserParameters.cs
+++ b/Confuser.Core/ConfuserParameters.cs
@@ -12,6 +12,8 @@ namespace Confuser.Core {
 		/// <value>The Confuser project.</value>
 		public ConfuserProject Project { get; set; }
 
+		public string namespace_prefix = null;
+
 		/// <summary>
 		///     Gets or sets the logger that used to log the protection process.
 		/// </summary>

--- a/Confuser.Renamer/RenamePhase.cs
+++ b/Confuser.Renamer/RenamePhase.cs
@@ -80,7 +80,7 @@ namespace Confuser.Renamer {
 						typeDef.Namespace = "";
 					}
 					else {
-						typeDef.Namespace = service.ObfuscateName(typeDef.Namespace, mode);
+						typeDef.Namespace = context.namespace_prefix + service.ObfuscateName(typeDef.Namespace, mode);
 						typeDef.Name = service.ObfuscateName(typeDef.Name, mode);
 					}
 					foreach (var param in typeDef.GenericParameters)


### PR DESCRIPTION
In use, different products need to be obfuscated. If the obfuscated namespaces are the same, conflicts will occur. Therefore, it is necessary to add different prefixes during obfuscation. This submission adds the function of passing in prefixes from the command line.