### PR TITLE
Solved reference proxy error

### DIFF
--- a/Confuser2.sln
+++ b/Confuser2.sln
@@ -103,6 +103,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "270_EnumArrayConstantProtec
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "270_EnumArrayConstantProtection.Test", "Tests\270_EnumArrayConstantProtection.Test\270_EnumArrayConstantProtection.Test.csproj", "{DB234158-233E-4EC4-A2CE-EF02699563A2}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferenceProxy", "Tests\ReferenceProxy\ReferenceProxy.csproj", "{FE068381-F170-4C37-82C4-11A81FE60F1A}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReferenceProxy.Test", "Tests\ReferenceProxy.Test\ReferenceProxy.Test.csproj", "{2C059FE7-C868-4C6D-AFA0-D62BA3C1B2E1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -281,6 +285,14 @@ Global
 		{DB234158-233E-4EC4-A2CE-EF02699563A2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DB234158-233E-4EC4-A2CE-EF02699563A2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DB234158-233E-4EC4-A2CE-EF02699563A2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FE068381-F170-4C37-82C4-11A81FE60F1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FE068381-F170-4C37-82C4-11A81FE60F1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FE068381-F170-4C37-82C4-11A81FE60F1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FE068381-F170-4C37-82C4-11A81FE60F1A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2C059FE7-C868-4C6D-AFA0-D62BA3C1B2E1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2C059FE7-C868-4C6D-AFA0-D62BA3C1B2E1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2C059FE7-C868-4C6D-AFA0-D62BA3C1B2E1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2C059FE7-C868-4C6D-AFA0-D62BA3C1B2E1}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -321,6 +333,8 @@ Global
 		{C10599E3-5A79-484F-940B-E4B61F256466} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{7C6D1CCD-D4DF-426A-B5D6-A6B5F13D0091} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{DB234158-233E-4EC4-A2CE-EF02699563A2} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{FE068381-F170-4C37-82C4-11A81FE60F1A} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{2C059FE7-C868-4C6D-AFA0-D62BA3C1B2E1} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D937D9E-E04B-4A68-B639-D4260473A388}

--- a/Tests/ReferenceProxy.Test/ReferenceProxy.Test.csproj
+++ b/Tests/ReferenceProxy.Test/ReferenceProxy.Test.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <IsPackable>False</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Confuser.UnitTest\Confuser.UnitTest.csproj" />
+    <ProjectReference Include="..\ReferenceProxy\ReferenceProxy.csproj" />
+  </ItemGroup>
+
+
+</Project>

--- a/Tests/ReferenceProxy.Test/ReferenceProxyTest.cs
+++ b/Tests/ReferenceProxy.Test/ReferenceProxyTest.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Confuser.Core;
+using Confuser.Core.Project;
+using Confuser.UnitTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace ReferenceProxy.Test {
+	public class ReferenceProxyTest : TestBase {
+		public ReferenceProxyTest(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+		[Theory]
+		[MemberData(nameof(ReferenceProxyData))]
+		[Trait("Category", "Protection")]
+		[Trait("Protection", "ref proxy")]
+		[Trait("Issue", "https://github.com/mkaring/ConfuserEx/issues/229")]
+		public async Task ReferenceProxy(string mode, string encoding, bool internalRefs, bool typeErasure) =>
+			await Run(
+				"ReferenceProxy.exe",
+				Array.Empty<string>(),
+				new SettingItem<Protection>("ref proxy") {
+					["mode"] = mode,
+					["encoding"] = encoding,
+					["internal"] = internalRefs.ToString(),
+					["typeErasure"] = typeErasure.ToString()
+				},
+				outputDirSuffix: $"_{mode}_{encoding}_{internalRefs}_{typeErasure}"
+			);
+
+		public static IEnumerable<object[]> ReferenceProxyData() {
+			foreach (var mode in new[] { "mild", "strong" })
+				foreach (var encoding in new[] { "normal", "expression", "x86" })
+					foreach (var internalRefs in new[] { true, false })
+						foreach (var typeErasure in new[] { true, false }) {
+							if (mode.Equals("mild") && !encoding.Equals("normal")) continue;
+							yield return new object[] { mode, encoding, internalRefs, typeErasure };
+						}
+		}
+	}
+}

--- a/Tests/ReferenceProxy/Program.cs
+++ b/Tests/ReferenceProxy/Program.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace ReferenceProxy {
+	class Program {
+		static int Main(string[] args) {
+			Console.WriteLine("START");
+			foreach (var arg in args)
+				Console.WriteLine(arg);
+			Console.WriteLine("END");
+			return 42;
+		}
+	}
+}

--- a/Tests/ReferenceProxy/ReferenceProxy.csproj
+++ b/Tests/ReferenceProxy/ReferenceProxy.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net461</TargetFramework>
+    <StartupObject>ReferenceProxy.Program</StartupObject>
+  </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
The strong mode of the reference proxy encountered an error, that caused the normal and the expression mode to fail at runtime. The reason for this issue was that the key decode multiplication was added randomly before or after the instructions that were used to generate the placeholder parameters. The traceservice correctly identified the "add" instruction as source for the parameter of the method, how ever adding the konstant directly before the add instruction modified the stack and caused a wrong addition to take place.

The issue is fixed, by extending the tracing to resolve all the instructions that take part in constructing the value that parameter. This way the new constant may be randomly placed before or after the entire stack that produces the parameter. This resolves the issue. The x86 was uneffected, because it always creates the call after the instructions that create the parameter and never before.

A unit test was added to verify the correct function of the reference proxy protection.

fixes #229 