### PR TITLE
Fixed Type Scrambler for C++/CLI modules

### DIFF
--- a/Confuser.Protections/TypeScrambler/ScramblePhase.cs
+++ b/Confuser.Protections/TypeScrambler/ScramblePhase.cs
@@ -5,7 +5,7 @@ using Confuser.Protections.TypeScrambler.Scrambler;
 using dnlib.DotNet;
 
 namespace Confuser.Protections.TypeScrambler {
-	internal sealed class ScramblePhase : ProtectionPhase {
+	sealed class ScramblePhase : ProtectionPhase {
 		public ScramblePhase(TypeScrambleProtection parent) : base(parent) { }
 
 		public override ProtectionTargets Targets => ProtectionTargets.Types | ProtectionTargets.Methods;
@@ -30,7 +30,8 @@ namespace Confuser.Protections.TypeScrambler {
 			foreach (var def in context.CurrentModule.FindDefinitions().WithProgress(context.Logger)) {
 				switch (def) {
 					case MethodDef md:
-						md.ReturnType = rewriter.UpdateSignature(md.ReturnType);
+						if (md.HasReturnType)
+							md.ReturnType = rewriter.UpdateSignature(md.ReturnType);
 						if (md.HasBody) {
 							rewriter.ProcessBody(md);
 						}

--- a/Confuser.Protections/TypeScrambler/Scrambler/ScannedItem.cs
+++ b/Confuser.Protections/TypeScrambler/Scrambler/ScannedItem.cs
@@ -35,6 +35,10 @@ namespace Confuser.Protections.TypeScrambler.Scrambler {
 			// Get proper type.
 			t = SignatureUtils.GetLeaf(t);
 
+			// scrambling voids leads to peverify errors, better leave them out.
+			if (t.ElementType == ElementType.Void)
+				return false;
+
 			if (!Generics.ContainsKey(t)) {
 				GenericParam newGenericParam;
 				if (t.IsGenericMethodParameter) {

--- a/Confuser.Protections/TypeScrambler/Scrambler/ScannedMethod.cs
+++ b/Confuser.Protections/TypeScrambler/Scrambler/ScannedMethod.cs
@@ -90,6 +90,8 @@ namespace Confuser.Protections.TypeScrambler.Scrambler {
 			// PInvoke implementations won't work with this.
 			if (method.IsPinvokeImpl) return false;
 
+			if (method.DeclaringType.IsGlobalModuleType) return false;
+
 			return true;
 		}
 

--- a/Confuser.Protections/TypeScrambler/Scrambler/ScannedMethod.cs
+++ b/Confuser.Protections/TypeScrambler/Scrambler/ScannedMethod.cs
@@ -39,9 +39,10 @@ namespace Confuser.Protections.TypeScrambler.Scrambler {
 				}
 			}
 
-			if (TargetMethod.ReturnType != TargetMethod.Module.CorLibTypes.Void) {
+			if (TargetMethod.HasReturnType) {
 				RegisterGeneric(TargetMethod.ReturnType);
 			}
+			
 			foreach (var param in TargetMethod.Parameters.Where(ProcessParameter))
 				RegisterGeneric(param.Type);
 
@@ -129,7 +130,7 @@ namespace Confuser.Protections.TypeScrambler.Scrambler {
 					$"{nameof(parameter)}.Type == {nameof(TargetMethod)}.MethodSig.Params[{nameof(parameter)}.MethodSigIndex]");
 			}
 
-			if (TargetMethod.ReturnType != TargetMethod.Module.CorLibTypes.Void)
+			if (TargetMethod.HasReturnType)
 				TargetMethod.ReturnType = ConvertToGenericIfAvalible(TargetMethod.ReturnType);
 
 			Debug.Assert(TargetMethod.ReturnType == TargetMethod.MethodSig.RetType,

--- a/Confuser.Protections/TypeScrambler/Scrambler/ScannedType.cs
+++ b/Confuser.Protections/TypeScrambler/Scrambler/ScannedType.cs
@@ -32,8 +32,8 @@ namespace Confuser.Protections.TypeScrambler.Scrambler {
 			// Delegates are something that shouldn't be touched.
 			if (type.IsDelegate) return false;
 
-			// No entrypoints
-			if (type.Methods.Any(x => x.Module.EntryPoint == x)) return false;
+			// No entrypoints or global types
+			if (type.Methods.Any(x => x.Module.EntryPoint == x) || type.IsGlobalModuleType) return false;
 
 			if (type.IsValueType) return false;
 


### PR DESCRIPTION
Hello,
I've fixed the problems with the Type Scrambler mentioned in issue #244. When protecting the provided file from the issue it now works properly. There were actually three small issues at play here.

* Checking if the method had a return type was bugged and didn't take into account modifier signatures.
* Scrambling of "void" causes errors in peverify and thus should probably be skipped.
* Disabled scrambling of members in the <Module> type as C++/CLI modules contain runtime code in that type which is not called using traditional CIL calls which can be easily analyzed. Instead, they are called from outside or by function pointers.