### PR TITLE
Changing header of compression block to 4 byte integer

### DIFF
--- a/Confuser.Core/Services/CompressionService.cs
+++ b/Confuser.Core/Services/CompressionService.cs
@@ -96,10 +96,13 @@ namespace Confuser.Core.Services {
 			var encoder = new Encoder();
 			encoder.SetCoderProperties(propIDs, properties);
 			encoder.WriteCoderProperties(x);
-			Int64 fileSize;
-			fileSize = data.Length;
-			for (int i = 0; i < 8; i++)
-				x.WriteByte((Byte)(fileSize >> (8 * i)));
+
+			var length = BitConverter.GetBytes(data.Length);
+			if (!BitConverter.IsLittleEndian)
+				Array.Reverse(length);
+			
+			// Store 4 byte length value (little-endian)
+			x.Write(length, 0, sizeof(int));
 
 			ICodeProgress progress = null;
 			if (progressFunc != null)


### PR DESCRIPTION
This cleans up a lot of strange casts and should allow to run the decompression code to work a bit more consistently.

This may help the issue reported in #301 #348