### PR TITLE
Fixed msbuild crash when building without symbol.map

### DIFF
--- a/Confuser.MSBuild.Tasks/build/Confuser.MSBuild.targets
+++ b/Confuser.MSBuild.Tasks/build/Confuser.MSBuild.targets
@@ -119,7 +119,7 @@
       <CopyConfuserSymbolsMapToOutputDirectory Condition="'$(CopyConfuserSymbolsMapToOutputDirectory)'==''">true</CopyConfuserSymbolsMapToOutputDirectory>
     </PropertyGroup>
 
-    <ItemGroup>
+    <ItemGroup Condition="Exists('$(ConfuserIntermediateOutputPath)symbols.map')">
       <_SymbolsMapSourceFiles Include="$(ConfuserIntermediateOutputPath)symbols.map" />
       <_SymbolsMapDestinationFiles Include="$(_SymbolsMapOutputDirectory)$(ConfuserSymbolFileName)" />
     </ItemGroup>


### PR DESCRIPTION
The msbuild integration was crashing in case the project was building without the symbol map.