### PR TITLE
#319 Fixed falsing adding generic signature override

### DIFF
--- a/Confuser.Renamer/Analyzers/VTableAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/VTableAnalyzer.cs
@@ -320,11 +320,19 @@ namespace Confuser.Renamer.Analyzers {
 
 			var targetMethodSig = targetMethod.MethodSig;
 			var overrideMethodSig = methodOverride.MethodDeclaration.MethodSig;
-			if (methodOverride.MethodDeclaration.DeclaringType is TypeSpec spec && spec.TypeSig is GenericInstSig genericInstSig) {
+			
+			targetMethodSig = ResolveGenericSignature(targetMethod, targetMethodSig);
+			overrideMethodSig = ResolveGenericSignature(methodOverride.MethodDeclaration, overrideMethodSig);
+
+			return comparer.Equals(targetMethodSig, overrideMethodSig);
+		}
+
+		static MethodSig ResolveGenericSignature(IMemberRef method, MethodSig overrideMethodSig) {
+			if (method.DeclaringType is TypeSpec spec && spec.TypeSig is GenericInstSig genericInstSig) {
 				overrideMethodSig = GenericArgumentResolver.Resolve(overrideMethodSig, genericInstSig.GenericArguments);
 			}
 
-			return comparer.Equals(targetMethodSig, overrideMethodSig);
+			return overrideMethodSig;
 		}
 
 		public void PreRename(ConfuserContext context, INameService service, ProtectionParameters parameters, IDnlibDef def) {


### PR DESCRIPTION
This error caused the detection if a specific override is already present to fail, in case the overwrite signature is generic. This caused an runtime error when executing the assembly in the mono runtime.

fixes #319 