### PR TITLE
Renaming improvements

### DIFF
--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -38,8 +38,9 @@ namespace Confuser.Renamer {
 					foreach (var res in module.Resources)
 						service.AddReservedIdentifier(res.Name);
 				}
-				else
-					service.SetOriginalName(def);
+				else {
+					service.StoreNames(def);
+				}
 
 				if (def is TypeDef typeDef) {
 					service.GetVTables().GetVTable(typeDef);

--- a/Confuser.Renamer/Analyzers/VTableAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/VTableAnalyzer.cs
@@ -55,9 +55,9 @@ namespace Confuser.Renamer.Analyzers {
 					var typeDef = type.BaseType?.ResolveTypeDef();
 					var baseMethod = typeDef?.FindMethod(methodDef.Name, methodDef.Signature as MethodSig);
 					if (baseMethod != null) {
-						string unifiedName = service.GetOriginalFullName(slot.Overrides.MethodDef);
-						service.SetOriginalName(slot.MethodDef, unifiedName);
-						service.SetOriginalName(baseMethod, unifiedName);
+						string unifiedName = service.GetNormalizedName(slot.Overrides.MethodDef);
+						service.SetNormalizedName(slot.MethodDef, unifiedName);
+						service.SetNormalizedName(baseMethod, unifiedName);
 					}
 				}
 			}

--- a/Confuser.Renamer/DisplayNormalizedName.cs
+++ b/Confuser.Renamer/DisplayNormalizedName.cs
@@ -1,0 +1,12 @@
+namespace Confuser.Renamer {
+	public struct DisplayNormalizedName {
+		public string DisplayName { get; }
+
+		public string NormalizedName { get; }
+
+		public DisplayNormalizedName(string displayName, string normalizedName) {
+			DisplayName = displayName;
+			NormalizedName = normalizedName;
+		}
+	}
+}

--- a/Confuser.Renamer/ReferenceUtilities.cs
+++ b/Confuser.Renamer/ReferenceUtilities.cs
@@ -8,7 +8,7 @@ namespace Confuser.Renamer {
 				return builder.AppendHashedIdentifier("Name", def.FullName);
 
 			builder.Append("Original Name").Append(": ");
-			builder.Append(nameService.GetOriginalFullName(def));
+			builder.Append(nameService.GetDisplayName(def));
 			builder.Append("; ");
 			return builder.AppendHashedIdentifier("Name", def.FullName);
 		}

--- a/Confuser.Renamer/ReversibleRenamer.cs
+++ b/Confuser.Renamer/ReversibleRenamer.cs
@@ -5,8 +5,8 @@ using System.Text;
 
 namespace Confuser.Renamer {
 	public class ReversibleRenamer {
-		RijndaelManaged cipher;
-		byte[] key;
+		readonly RijndaelManaged cipher;
+		readonly byte[] key;
 
 		public ReversibleRenamer(string password) {
 			cipher = new RijndaelManaged();
@@ -14,13 +14,32 @@ namespace Confuser.Renamer {
 				cipher.Key = key = sha.ComputeHash(Encoding.UTF8.GetBytes(password));
 		}
 
-		static string Base64Encode(byte[] buf) {
-			return Convert.ToBase64String(buf).Trim('=').Replace('+', '$').Replace('/', '_');
+		public string Encrypt(string name) {
+			byte ivId = GetIVId(name);
+			cipher.IV = GetIV(ivId);
+			var buf = Encoding.UTF8.GetBytes(name);
+
+			using (var ms = new MemoryStream()) {
+				ms.WriteByte(ivId);
+				using (var stream = new CryptoStream(ms, cipher.CreateEncryptor(), CryptoStreamMode.Write)) {
+					stream.Write(buf, 0, buf.Length);
+					stream.FlushFinalBlock();
+					return Base64Encode(ms.GetBuffer(), (int)ms.Length);
+				}
+			}
 		}
 
-		static byte[] Base64Decode(string str) {
-			str = str.Replace('$', '+').Replace('_', '/').PadRight((str.Length + 3) & ~3, '=');
-			return Convert.FromBase64String(str);
+		public string Decrypt(string name) {
+			using (var ms = new MemoryStream(Base64Decode(name))) {
+				byte ivId = (byte)ms.ReadByte();
+				cipher.IV = GetIV(ivId);
+
+				using (var result = new MemoryStream()) {
+					using (var stream = new CryptoStream(ms, cipher.CreateDecryptor(), CryptoStreamMode.Read))
+						stream.CopyTo(result);
+					return Encoding.UTF8.GetString(result.GetBuffer(), 0, (int)result.Length);
+				}
+			}
 		}
 
 		byte[] GetIV(byte ivId) {
@@ -37,32 +56,48 @@ namespace Confuser.Renamer {
 			return x;
 		}
 
-		public string Encrypt(string name) {
-			byte ivId = GetIVId(name);
-			cipher.IV = GetIV(ivId);
-			var buf = Encoding.UTF8.GetBytes(name);
+		static string Base64Encode(byte[] buffer, int length) {
+			int inputUnpaddedLength = 4 * length / 3;
+			var outArray = new char[(inputUnpaddedLength + 3) & ~3];
+			Convert.ToBase64CharArray(buffer, 0, length, outArray, 0);
 
-			using (var ms = new MemoryStream()) {
-				ms.WriteByte(ivId);
-				using (var stream = new CryptoStream(ms, cipher.CreateEncryptor(), CryptoStreamMode.Write))
-					stream.Write(buf, 0, buf.Length);
+			var result = new StringBuilder(inputUnpaddedLength);
+			foreach (var oldChar in outArray) {
+				if (oldChar == '=') {
+					break;
+				}
 
-				buf = ms.ToArray();
-				return Base64Encode(buf);
+				result.Append(oldChar == '+'
+					? '$'
+					: oldChar == '/'
+						? '_'
+						: oldChar);
 			}
+
+			return result.ToString();
 		}
 
-		public string Decrypt(string name) {
-			using (var ms = new MemoryStream(Base64Decode(name))) {
-				byte ivId = (byte)ms.ReadByte();
-				cipher.IV = GetIV(ivId);
+		static byte[] Base64Decode(string str) {
+			var newLength = (str.Length + 3) & ~3;
+			var inArray = new char[newLength];
+			for (int index = 0; index < newLength; index++) {
+				char newChar;
+				if (index < str.Length) {
+					char oldChar = str[index];
+					newChar = oldChar == '$'
+						? '+'
+						: oldChar == '_'
+							? '/'
+							: oldChar;
+				}
+				else {
+					newChar = '=';
+				}
 
-				var result = new MemoryStream();
-				using (var stream = new CryptoStream(ms, cipher.CreateDecryptor(), CryptoStreamMode.Read))
-					stream.CopyTo(result);
-
-				return Encoding.UTF8.GetString(result.ToArray());
+				inArray[index] = newChar;
 			}
+
+			return Convert.FromBase64CharArray(inArray, 0, inArray.Length);
 		}
 	}
 }

--- a/ConfuserEx/StackTraceDecoder.xaml.cs
+++ b/ConfuserEx/StackTraceDecoder.xaml.cs
@@ -41,7 +41,7 @@ namespace ConfuserEx {
 			}
 
 			if (!error) {
-				stackTrace.Text = _messageDeobfuscator.Deobfuscate(stackTrace.Text);
+				stackTrace.Text = _messageDeobfuscator.DeobfuscateMessage(stackTrace.Text);
 			}
 		}
 	}

--- a/Tests/MessageDeobfuscation.Test/MessageDeobfuscationTest.cs
+++ b/Tests/MessageDeobfuscation.Test/MessageDeobfuscationTest.cs
@@ -26,13 +26,46 @@ namespace MessageDeobfuscation.Test {
 			await Run(
 				"MessageDeobfuscation.exe",
 				expectedObfuscatedOutput,
-				new SettingItem<Protection>("rename") {["mode"] = renameMode},
+				new SettingItem<Protection>("rename") { ["mode"] = renameMode },
 				$"SymbolsMap_{renameMode}",
 				seed: "1234",
 				postProcessAction: outputPath => {
-					var messageDeobfuscator = MessageDeobfuscator.Load(Path.Combine(outputPath, "symbols.map"));
-					var deobfuscated = messageDeobfuscator.Deobfuscate(string.Join(Environment.NewLine, expectedObfuscatedOutput));
-					Assert.Equal(_expectedDeobfuscatedOutput, deobfuscated);
+					var deobfuscator = MessageDeobfuscator.Load(Path.Combine(outputPath, "symbols.map"));
+					var deobfuscatedMessage =
+						deobfuscator.DeobfuscateMessage(string.Join(Environment.NewLine, expectedObfuscatedOutput));
+
+					string classId, nestedClassId, methodId, fieldId, propertyId, eventId;
+					if (renameMode == nameof(RenameMode.Decodable)) {
+						classId = "_OokpKOmal5JNZMPvSAFgHLHjBke";
+						nestedClassId = "_tc5CFDIJ2J9Fx3ehd3sgjTMAxCaA";
+						methodId = "_zbgDV4jbK6Oi9WBq66uG2ct7IoRA";
+						fieldId = "_QHxqC1xaBFmUQawCZSOQpattICo";
+						propertyId = "_FJthtfOBOiQFgVDIymbi3wwJoeN";
+						eventId = "_cbPBZqkDuaNXOkmJtacrG2uYfZs";
+					}
+					else {
+						classId = "_g";
+						nestedClassId = "_e";
+						methodId = "_C";
+						fieldId = "_d";
+						propertyId = "_E";
+						eventId = "_b";
+					}
+
+					CheckName("MessageDeobfuscation.Class", "MessageDeobfuscation.Class",
+						classId, deobfuscator);
+					CheckName("MessageDeobfuscation.Class/NestedClass", "NestedClass",
+						nestedClassId, deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Method(System.String,System.Int32)", "Method",
+						methodId, deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Field", "Field",
+						fieldId, deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Property", "Property",
+						propertyId, deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Event", "Event",
+						eventId, deobfuscator);
+
+					Assert.Equal(_expectedDeobfuscatedOutput, deobfuscatedMessage);
 					return Task.Delay(0);
 				}
 			);
@@ -50,9 +83,9 @@ namespace MessageDeobfuscation.Test {
 				new object[] {
 					nameof(RenameMode.Sequential),
 					new[] {
-					"Exception",
-					"   at _A._C._b(String )",
-					"   at _B._c()"
+						"Exception",
+						"   at _g._e._c(String )",
+						"   at _B._f()"
 					}
 				}
 			};
@@ -70,15 +103,39 @@ namespace MessageDeobfuscation.Test {
 			await Run(
 				"MessageDeobfuscation.exe",
 				expectedObfuscatedOutput,
-				new SettingItem<Protection>("rename") {["mode"] = "reversible", ["password"] = password},
+				new SettingItem<Protection>("rename") {
+					["mode"] = "reversible",
+					["password"] = password,
+					["renPdb"] = "true"
+				},
 				"Password",
 				postProcessAction: outputPath => {
-					var messageDeobfuscator = new MessageDeobfuscator(password);
-					var deobfuscated = messageDeobfuscator.Deobfuscate(string.Join(Environment.NewLine, expectedObfuscatedOutput));
-					Assert.Equal(_expectedDeobfuscatedOutput, deobfuscated);
+					var deobfuscator = new MessageDeobfuscator(password);
+					var deobfuscatedMessage = deobfuscator.DeobfuscateMessage(string.Join(Environment.NewLine, expectedObfuscatedOutput));
+
+					CheckName("MessageDeobfuscation.Class", "MessageDeobfuscation.Class",
+						"oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8", deobfuscator);
+					CheckName("MessageDeobfuscation.Class/NestedClass", "NestedClass",
+						"V1M$X52eDxP6ElgdFrRDlF0KSZU31AmQaiXXgzyoeJJ4KV64JBpi0Bh25Xdje$vCxw", deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Method(System.String,System.Int32)", "Method",
+						"CPiRF0I_h5xVXKPEtJXNA7cLoPPS4vhkcjcJi6MAreEi2dBd0rRGyabz9ko1cgWS46oQIMTt_U99FxMd$wpcMBI", deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Field", "Field",
+						"EbUjRcrC76NnA7RJlhQffrdNtUhGQ3K5irENJz724HX_R45xF8Tm$vzXOkAiVX4bXA", deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Property", "Property",
+						"jpG4Jhvg51oUy7PG8hUhxDmJkR1IVttcUFtkOHedcZ2BvCUAjb2SvUsd3q9IoA2LEQ", deobfuscator);
+					CheckName("MessageDeobfuscation.Class::Event", "Event",
+						"NdAzNJfOt9g8GfsT5YEikaIAKenWzJC2RbWKmG8rcYU4f2t_KXIZp4wSkiAmLQe8sA", deobfuscator);
+
+					Assert.Equal(_expectedDeobfuscatedOutput, deobfuscatedMessage);
 					return Task.Delay(0);
 				}
 			);
+		}
+
+		void CheckName(string expectedFullName, string expectedShortName, string obfuscatedName, MessageDeobfuscator messageDeobfuscator) {
+			var fullName = messageDeobfuscator.DeobfuscateSymbol(obfuscatedName, false);
+			Assert.Equal(expectedFullName, fullName);
+			Assert.Equal(expectedShortName, MessageDeobfuscator.ExtractShortName(fullName));
 		}
 	}
 }

--- a/Tests/MessageDeobfuscation.Test/MessageDeobfuscationTest.cs
+++ b/Tests/MessageDeobfuscation.Test/MessageDeobfuscationTest.cs
@@ -52,18 +52,24 @@ namespace MessageDeobfuscation.Test {
 						eventId = "_b";
 					}
 
+					void CheckName(string expectedFullName, string expectedShortName, string obfuscatedName) {
+						var fullName = deobfuscator.DeobfuscateSymbol(obfuscatedName, false);
+						Assert.Equal(expectedFullName, fullName);
+						Assert.Equal(expectedShortName, MessageDeobfuscator.ExtractShortName(fullName));
+					}
+
 					CheckName("MessageDeobfuscation.Class", "MessageDeobfuscation.Class",
-						classId, deobfuscator);
+						classId);
 					CheckName("MessageDeobfuscation.Class/NestedClass", "NestedClass",
-						nestedClassId, deobfuscator);
+						nestedClassId);
 					CheckName("MessageDeobfuscation.Class::Method(System.String,System.Int32)", "Method",
-						methodId, deobfuscator);
+						methodId);
 					CheckName("MessageDeobfuscation.Class::Field", "Field",
-						fieldId, deobfuscator);
+						fieldId);
 					CheckName("MessageDeobfuscation.Class::Property", "Property",
-						propertyId, deobfuscator);
+						propertyId);
 					CheckName("MessageDeobfuscation.Class::Event", "Event",
-						eventId, deobfuscator);
+						eventId);
 
 					Assert.Equal(_expectedDeobfuscatedOutput, deobfuscatedMessage);
 					return Task.Delay(0);
@@ -96,8 +102,8 @@ namespace MessageDeobfuscation.Test {
 		public async Task MessageDeobfuscationWithPassword() {
 			var expectedObfuscatedOutput = new[] {
 				"Exception",
-				"   at oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8.V1M$X52eDxP6ElgdFrRDlF0KSZU31AmQaiXXgzyoeJJ4KV64JBpi0Bh25Xdje$vCxw.fUHV$KyBiFTUH0$GNDHVx6XvtlZWHnzVgRO9N2M$jw5ysYWJWaUSMQYtPDT$wa$6MarZQoNxnbR_9cn$A2XXvRY(String )",
-				"   at EbUjRcrC76NnA7RJlhQffrfp$vMGHdDfqtVFtWrAOPyD.swzvaIVl3W8yDi8Ii3P1j_V9JC8eVu2JgvNNjeVDYc4bOHH37cCBf0_3URE_8UcWPQ()"
+				"   at oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8.CE8t0VDPQk9$jgv1XuRwt1k.FhsPrCLqIAaPKe7abGklvY4(String )",
+				"   at EbUjRcrC76NnA7RJlhQffrfp$vMGHdDfqtVFtWrAOPyD.xgIw9voebB21PlxPFA_hs60()"
 			};
 			string password = "password";
 			await Run(
@@ -113,29 +119,22 @@ namespace MessageDeobfuscation.Test {
 					var deobfuscator = new MessageDeobfuscator(password);
 					var deobfuscatedMessage = deobfuscator.DeobfuscateMessage(string.Join(Environment.NewLine, expectedObfuscatedOutput));
 
-					CheckName("MessageDeobfuscation.Class", "MessageDeobfuscation.Class",
-						"oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8", deobfuscator);
-					CheckName("MessageDeobfuscation.Class/NestedClass", "NestedClass",
-						"V1M$X52eDxP6ElgdFrRDlF0KSZU31AmQaiXXgzyoeJJ4KV64JBpi0Bh25Xdje$vCxw", deobfuscator);
-					CheckName("MessageDeobfuscation.Class::Method(System.String,System.Int32)", "Method",
-						"CPiRF0I_h5xVXKPEtJXNA7cLoPPS4vhkcjcJi6MAreEi2dBd0rRGyabz9ko1cgWS46oQIMTt_U99FxMd$wpcMBI", deobfuscator);
-					CheckName("MessageDeobfuscation.Class::Field", "Field",
-						"EbUjRcrC76NnA7RJlhQffrdNtUhGQ3K5irENJz724HX_R45xF8Tm$vzXOkAiVX4bXA", deobfuscator);
-					CheckName("MessageDeobfuscation.Class::Property", "Property",
-						"jpG4Jhvg51oUy7PG8hUhxDmJkR1IVttcUFtkOHedcZ2BvCUAjb2SvUsd3q9IoA2LEQ", deobfuscator);
-					CheckName("MessageDeobfuscation.Class::Event", "Event",
-						"NdAzNJfOt9g8GfsT5YEikaIAKenWzJC2RbWKmG8rcYU4f2t_KXIZp4wSkiAmLQe8sA", deobfuscator);
+					void CheckName(string expectedName, string obfuscatedName) {
+						var name = deobfuscator.DeobfuscateSymbol(obfuscatedName, true);
+						Assert.Equal(expectedName, name);
+					}
+
+					CheckName("MessageDeobfuscation.Class", "oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8");
+					CheckName("NestedClass", "CE8t0VDPQk9$jgv1XuRwt1k");
+					CheckName("Method", "jevJU4p4yNrAYGqN7GkRWaI");
+					CheckName("Field", "3IS4xsnUsvDQZop6e4WmNVw");
+					CheckName("Property", "917VMBMNYHd0kfnnNkgeJ10");
+					CheckName("Event", "AIyINk7kgFLFc73Md8Nu8Z0");
 
 					Assert.Equal(_expectedDeobfuscatedOutput, deobfuscatedMessage);
 					return Task.Delay(0);
 				}
 			);
-		}
-
-		void CheckName(string expectedFullName, string expectedShortName, string obfuscatedName, MessageDeobfuscator messageDeobfuscator) {
-			var fullName = messageDeobfuscator.DeobfuscateSymbol(obfuscatedName, false);
-			Assert.Equal(expectedFullName, fullName);
-			Assert.Equal(expectedShortName, MessageDeobfuscator.ExtractShortName(fullName));
 		}
 	}
 }

--- a/Tests/MessageDeobfuscation/Program.cs
+++ b/Tests/MessageDeobfuscation/Program.cs
@@ -2,6 +2,14 @@ using System;
 
 namespace MessageDeobfuscation {
 	class Class {
+		public string Method(string param1, int param2) => "method";
+
+		public string Field = "field";
+
+		public string Property => "property";
+
+		public event EventHandler<string> Event;
+
 		public class NestedClass {
 			internal string Method(string param) {
 				throw new Exception($"Exception");
@@ -16,9 +24,9 @@ namespace MessageDeobfuscation {
 			try {
 				new Class.NestedClass().Method("param");
 			}
-			catch (Exception e) {
-				Console.WriteLine(e.Message);
-				Console.WriteLine(e.StackTrace);
+			catch (Exception ex) {
+				Console.WriteLine(ex.Message);
+				Console.WriteLine(ex.StackTrace);
 			}
 			Console.WriteLine("END");
 			return 42;

--- a/Tests/MethodOverloading.Test/MethodOverloadingTest.cs
+++ b/Tests/MethodOverloading.Test/MethodOverloadingTest.cs
@@ -54,12 +54,18 @@ namespace MethodOverloading.Test {
 						Assert.Equal("MethodOverloading.Class", symbols["_iyWU2GdYVZxajP8BQlt8KKTy6qQ"]);
 						Assert.Equal("MethodOverloading.Program/NestedClass", symbols["_CZIbNVHU7wPJyGhgOcTnIUsFtC0"]);
 						Assert.Equal("OverloadedMethod", symbols["_phF8iy7Y79cwt3EaAFmJzW2bGch"]);
+						Assert.Equal("Field", symbols["_6V1A5bTBinvE5uHIpOLYRNJLPo1"]);
+						Assert.Equal("Property", symbols["_R1FgkOY1t1oZChSgmkBM94XFyCj"]);
+						Assert.Equal("Event", symbols["_N2jFMB56aV9SI9hlSxW0X97PYvG"]);
 					}
 					else {
 						Assert.Equal("MethodOverloading.Class", symbols["_iyWU2GdYVZxajP8BQlt8KKTy6qQ"]);
 						Assert.Equal("MethodOverloading.Program/NestedClass", symbols["_CZIbNVHU7wPJyGhgOcTnIUsFtC0"]);
 						Assert.Equal("MethodOverloading.Program::OverloadedMethod(System.Object[])", symbols["_LzCBuBOSn49xbtKNsjuJxQZPIEW"]);
 						Assert.Equal("MethodOverloading.Program::OverloadedMethod(System.String)", symbols["_ywSbkiShk8k3qj7bBrEWEUfs9Km"]);
+						Assert.Equal("MethodOverloading.BaseClass::Field", symbols["_yqni8M5s0WdS43DWP1TXNaYbKEH"]);
+						Assert.Equal("MethodOverloading.BaseClass::Property", symbols["_3gBBhEIMEfnKvvSRKFDeTcFgGUPb"]);
+						Assert.Equal("MethodOverloading.BaseClass::Event", symbols["_MbPHu2jYmPBHHFrz4bK83xDAwLH"]);
 					}
 
 					return Task.Delay(0);

--- a/Tests/MethodOverloading/Program.cs
+++ b/Tests/MethodOverloading/Program.cs
@@ -21,6 +21,12 @@ namespace MethodOverloading {
 		public string Method(string param) => param;
 
 		public virtual string VirtualMethod() => "BaseClassVirtualMethod";
+
+		public string Field = "field";
+
+		public string Property => "property";
+
+		public event EventHandler<string> Event;
 	}
 
 	public class Class : BaseClass, IInterface {


### PR DESCRIPTION
* Decrease size for output assemblies if reversible renaming mode is used (use compressed prefixes instead of full names for declaring types)
* Decrease size for output identifiers (drop return type for all members) 