### PR TITLE
Improve reversible renamer protection with random password

### DIFF
--- a/Confuser.Core/CoreComponent.cs
+++ b/Confuser.Core/CoreComponent.cs
@@ -37,6 +37,9 @@ namespace Confuser.Core {
 		/// </summary>
 		public const string _APIStoreId = "Confuser.APIStore";
 
+		public const string SymbolsFileName = "symbols.map";
+		public const string PasswordFileName = "password";
+
 		readonly Marker marker;
 		readonly ConfuserContext _context;
 

--- a/Confuser.Core/Services/RandomService.cs
+++ b/Confuser.Core/Services/RandomService.cs
@@ -36,11 +36,7 @@ namespace Confuser.Core.Services {
 		/// <param name="seed">The seed data.</param>
 		/// <returns>The seed buffer.</returns>
 		internal static byte[] Seed(string seed) {
-			byte[] ret;
-			if (!string.IsNullOrEmpty(seed))
-				ret = Utils.SHA256(Encoding.UTF8.GetBytes(seed));
-			else
-				ret = Utils.SHA256(Guid.NewGuid().ToByteArray());
+			byte[] ret = Utils.SHA256(!string.IsNullOrEmpty(seed) ? Encoding.UTF8.GetBytes(seed) : Guid.NewGuid().ToByteArray());
 
 			for (int i = 0; i < 32; i++) {
 				ret[i] *= primes[i % primes.Length];
@@ -224,12 +220,15 @@ namespace Confuser.Core.Services {
 	internal class RandomService : IRandomService {
 		readonly byte[] seed; //32 bytes
 
+		public string SeedString { get; }
+
 		/// <summary>
 		///     Initializes a new instance of the <see cref="RandomService" /> class.
 		/// </summary>
 		/// <param name="seed">The project seed.</param>
 		public RandomService(string seed) {
-			this.seed = RandomGenerator.Seed(seed);
+			SeedString = string.IsNullOrEmpty(seed) ? Guid.NewGuid().ToString() : seed;
+			this.seed = RandomGenerator.Seed(SeedString);
 		}
 
 		/// <inheritdoc />
@@ -255,5 +254,7 @@ namespace Confuser.Core.Services {
 		/// <returns>The requested RNG.</returns>
 		/// <exception cref="System.ArgumentNullException"><paramref name="id" /> is <c>null</c>.</exception>
 		RandomGenerator GetRandomGenerator(string id);
+
+		string SeedString { get; }
 	}
 }

--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -151,22 +151,21 @@ namespace Confuser.Renamer {
 			else if (def is EventDef)
 				Analyze(service, context, parameters, (EventDef)def);
 			else if (def is ModuleDef) {
-				var generatedPassword = parameters.GetParameter<bool>(context, def, "generatePassword");
-				var password = parameters.GetParameter<string>(context, def, "password");
-				if (generatedPassword || password != null) {
-					var reversibleRenamer = service.reversibleRenamer;
-					if (reversibleRenamer == null) {
-						if (generatedPassword) {
-							password = context.Registry.GetService<IRandomService>().SeedString;
-						}
-						string dir = context.OutputDirectory;
-						string path = Path.GetFullPath(Path.Combine(dir, CoreComponent.PasswordFileName));
-						if (!Directory.Exists(dir))
-							Directory.CreateDirectory(dir);
-						File.WriteAllText(path, password);
-						service.reversibleRenamer = new ReversibleRenamer(password);
+				var renamingMode = parameters.GetParameter<RenameMode>(context, def, "mode");
+				if (renamingMode == RenameMode.Reversible && service.reversibleRenamer == null) {
+					var generatePassword = parameters.GetParameter<bool>(context, def, "generatePassword");
+					var password = parameters.GetParameter<string>(context, def, "password");
+					if (generatePassword || password == null) {
+						password = context.Registry.GetService<IRandomService>().SeedString;
 					}
+					string dir = context.OutputDirectory;
+					string path = Path.GetFullPath(Path.Combine(dir, CoreComponent.PasswordFileName));
+					if (!Directory.Exists(dir))
+						Directory.CreateDirectory(dir);
+					File.WriteAllText(path, password);
+					service.reversibleRenamer = new ReversibleRenamer(password);
 				}
+
 				service.SetCanRename(def, false);
 			}
 

--- a/Confuser.Renamer/AnalyzePhase.cs
+++ b/Confuser.Renamer/AnalyzePhase.cs
@@ -1,6 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using Confuser.Core;
+using Confuser.Core.Services;
 using Confuser.Renamer.Analyzers;
 using dnlib.DotNet;
 
@@ -30,6 +33,7 @@ namespace Confuser.Renamer {
 
 		protected override void Execute(ConfuserContext context, ProtectionParameters parameters) {
 			var service = (NameService)context.Registry.GetService<INameService>();
+
 			context.Logger.Debug("Building VTables & identifier list...");
 
 			foreach (ModuleDef moduleDef in parameters.Targets.OfType<ModuleDef>())
@@ -147,9 +151,22 @@ namespace Confuser.Renamer {
 			else if (def is EventDef)
 				Analyze(service, context, parameters, (EventDef)def);
 			else if (def is ModuleDef) {
-				var pass = parameters.GetParameter<string>(context, def, "password", null);
-				if (pass != null)
-					service.reversibleRenamer = new ReversibleRenamer(pass);
+				var generatedPassword = parameters.GetParameter<bool>(context, def, "generatePassword");
+				var password = parameters.GetParameter<string>(context, def, "password");
+				if (generatedPassword || password != null) {
+					var reversibleRenamer = service.reversibleRenamer;
+					if (reversibleRenamer == null) {
+						if (generatedPassword) {
+							password = context.Registry.GetService<IRandomService>().SeedString;
+						}
+						string dir = context.OutputDirectory;
+						string path = Path.GetFullPath(Path.Combine(dir, CoreComponent.PasswordFileName));
+						if (!Directory.Exists(dir))
+							Directory.CreateDirectory(dir);
+						File.WriteAllText(path, password);
+						service.reversibleRenamer = new ReversibleRenamer(password);
+					}
+				}
 				service.SetCanRename(def, false);
 			}
 

--- a/Confuser.Renamer/NameProtection.cs
+++ b/Confuser.Renamer/NameProtection.cs
@@ -61,8 +61,8 @@ namespace Confuser.Renamer {
 				if (map.Count == 0)
 					return;
 
-				string path = Path.GetFullPath(Path.Combine(context.OutputDirectory, "symbols.map"));
-				string dir = Path.GetDirectoryName(path);
+				string dir = context.OutputDirectory;
+				string path = Path.GetFullPath(Path.Combine(dir, CoreComponent.SymbolsFileName));
 				if (!Directory.Exists(dir))
 					Directory.CreateDirectory(dir);
 

--- a/Confuser.Renamer/ReversibleRenamer.cs
+++ b/Confuser.Renamer/ReversibleRenamer.cs
@@ -5,11 +5,11 @@ using System.Text;
 
 namespace Confuser.Renamer {
 	public class ReversibleRenamer {
-		readonly RijndaelManaged cipher;
+		readonly Aes cipher;
 		readonly byte[] key;
 
 		public ReversibleRenamer(string password) {
-			cipher = new RijndaelManaged();
+			cipher = Aes.Create();
 			using (var sha = SHA256.Create())
 				cipher.Key = key = sha.ComputeHash(Encoding.UTF8.GetBytes(password));
 		}


### PR DESCRIPTION
Enhancement and changes (the wiki should be updated):

* ~~Output `seed` file is generated in the output directory every obfuscation run~~
* ~~`seed=""` now is hardcoded seed, not random~~
* ~~For decoding stack traces with `reversible` renaming mode you need both `password` and `seed`. If you don't want to use random `seed` just add  `seed=""` (or any other hardcoded value) to `.crproj` config.~~

* New boolean option `generatePassword` that forces obfuscator to generate and use a new password on every run. The password is saved to `password` file in the output directory. Also, it's being generated if `mode` is reversible and `password` is not specified.

fix #383