### PR TITLE
Sequential renaming and performance improvements

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -81,9 +81,10 @@ namespace Confuser.CLI {
 					var proj = new ConfuserProject();
 					var templateModules = new List<ProjectModule>();
 
-					if (Path.GetExtension(files[files.Count - 1]) == ".crproj") {
-						LoadTemplateProject(files[files.Count - 1], proj, templateModules);
-						files.RemoveAt(files.Count - 1);
+					var lastIndex = files.Count - 1;
+					if (Path.GetExtension(files[lastIndex]) == ".crproj") {
+						LoadTemplateProject(files[lastIndex], proj, templateModules);
+						files.RemoveAt(lastIndex);
 					}
 
 					// Generate a ConfuserProject for input modules

--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -96,8 +96,8 @@ namespace Confuser.Core {
 				context.InternalResolver = asmResolver;
 				context.BaseDirectory = Path.Combine(Environment.CurrentDirectory, context.Project.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar);
 				context.OutputDirectory = Path.Combine(context.Project.BaseDirectory, context.Project.OutputDirectory.TrimEnd(Path.DirectorySeparatorChar) + Path.DirectorySeparatorChar);
-				foreach (string probePath in context.Project.ProbePaths)
-					asmResolver.PostSearchPaths.Insert(0, Path.Combine(context.BaseDirectory, probePath));
+				asmResolver.PostSearchPaths.InsertRange(0,
+					context.Project.ProbePaths.Select(probePath => Path.Combine(context.BaseDirectory, probePath)));
 
 				context.CheckCancellation();
 

--- a/Confuser.Core/DnlibUtils.cs
+++ b/Confuser.Core/DnlibUtils.cs
@@ -629,8 +629,8 @@ namespace Confuser.Core {
 			// Fix branch targets & add instructions
 			for (int i = currentIndex; i < collection.Count; i++) {
 				var instr = collection[i];
-				if (instr.Operand != null && instr.Operand is Instruction instrOp && instrMap.ContainsKey(instrOp))
-					instr.Operand = instrMap[instrOp];
+				if (instr.Operand != null && instr.Operand is Instruction instrOp && instrMap.TryGetValue(instrOp, out var operand))
+					instr.Operand = operand;
 				else if (instr.Operand is Instruction[] instructionArrayOp)
 					instr.Operand = instructionArrayOp.Select(target => instrMap[target]).ToArray();
 			}

--- a/Confuser.Core/Helpers/InjectHelper.cs
+++ b/Confuser.Core/Helpers/InjectHelper.cs
@@ -99,7 +99,7 @@ namespace Confuser.Core.Helpers {
 
 			newMethodDef.Signature = ctx.Importer.Import(methodDef.Signature);
 			newMethodDef.Parameters.UpdateParameterTypes();
-			
+
 			foreach (var paramDef in methodDef.ParamDefs)
 				newMethodDef.ParamDefs.Add(new ParamDefUser(paramDef.Name, paramDef.Sequence, paramDef.Attributes));
 
@@ -112,7 +112,7 @@ namespace Confuser.Core.Helpers {
 			if (methodDef.HasBody)
 				CopyMethodBody(methodDef, ctx, newMethodDef);
 		}
-		
+
 		static void CopyMethodBody(MethodDef methodDef, InjectContext ctx, MethodDef newMethodDef)
 		{
 			newMethodDef.Body = new CilBody(methodDef.Body.InitLocals, new List<Instruction>(),
@@ -155,8 +155,8 @@ namespace Confuser.Core.Helpers {
 
 			foreach (Instruction instr in newMethodDef.Body.Instructions)
 			{
-				if (instr.Operand != null && bodyMap.ContainsKey(instr.Operand))
-					instr.Operand = bodyMap[instr.Operand];
+				if (instr.Operand != null && bodyMap.TryGetValue(instr.Operand, out var operand))
+					instr.Operand = operand;
 				else if (instr.Operand is Instruction[] instructions)
 					instr.Operand = instructions.Select(target => (Instruction) bodyMap[target]).ToArray();
 			}
@@ -288,7 +288,7 @@ namespace Confuser.Core.Helpers {
 			public override ITypeDefOrRef Map(ITypeDefOrRef source) {
 				if (DefMap.TryGetValue(source, out var mappedRef))
 					return mappedRef as ITypeDefOrRef;
-				
+
 				// check if the assembly reference needs to be fixed.
 				if (source is TypeRef sourceRef) {
 					var targetAssemblyRef = TargetModule.GetAssemblyRef(sourceRef.DefinitionAssembly.Name);

--- a/Confuser.Core/Helpers/MutationHelper.cs
+++ b/Confuser.Core/Helpers/MutationHelper.cs
@@ -104,9 +104,7 @@ namespace Confuser.Core.Helpers {
 
 						var firstArgIndex = initialLoadInstructions.Select(method.Body.Instructions.IndexOf).Min();
 						Instruction[] arg = method.Body.Instructions.Skip(firstArgIndex).Take(i - firstArgIndex).ToArray();
-						for (int j = 0; j < arg.Length; j++)
-							method.Body.Instructions.RemoveAt(firstArgIndex);
-						method.Body.Instructions.RemoveAt(firstArgIndex);
+						method.Body.Instructions.RemoveRange(firstArgIndex, arg.Length + 1);
 						arg = repl(arg);
 						for (int j = arg.Length - 1; j >= 0; j--)
 							method.Body.Instructions.Insert(firstArgIndex, arg[j]);

--- a/Confuser.Core/Helpers/MutationHelper.cs
+++ b/Confuser.Core/Helpers/MutationHelper.cs
@@ -102,10 +102,10 @@ namespace Confuser.Core.Helpers {
 								pendingInstructions.Enqueue(method.Body.Instructions[argIndex]);
 						}
 
-						var firstArgIndex = initialLoadInstructions.Select(method.Body.Instructions.IndexOf).Min();
+						var firstArgIndex = initialLoadInstructions.Min(instruction =>
+							method.Body.Instructions.IndexOf(instruction));
 						var arg = method.Body.Instructions.Skip(firstArgIndex).Take(i - firstArgIndex).ToArray();
-						method.Body.Instructions.RemoveRange(firstArgIndex, arg.Length + 1);
-						method.Body.Instructions.InsertRange(firstArgIndex, repl(arg));
+						method.Body.Instructions.RemoveAndInsertRange(firstArgIndex, arg.Length + 1, repl(arg));
 						return;
 					}
 				}

--- a/Confuser.Core/Helpers/MutationHelper.cs
+++ b/Confuser.Core/Helpers/MutationHelper.cs
@@ -103,11 +103,9 @@ namespace Confuser.Core.Helpers {
 						}
 
 						var firstArgIndex = initialLoadInstructions.Select(method.Body.Instructions.IndexOf).Min();
-						Instruction[] arg = method.Body.Instructions.Skip(firstArgIndex).Take(i - firstArgIndex).ToArray();
+						var arg = method.Body.Instructions.Skip(firstArgIndex).Take(i - firstArgIndex).ToArray();
 						method.Body.Instructions.RemoveRange(firstArgIndex, arg.Length + 1);
-						arg = repl(arg);
-						for (int j = arg.Length - 1; j >= 0; j--)
-							method.Body.Instructions.Insert(firstArgIndex, arg[j]);
+						method.Body.Instructions.InsertRange(firstArgIndex, repl(arg));
 						return;
 					}
 				}

--- a/Confuser.Core/Marker.cs
+++ b/Confuser.Core/Marker.cs
@@ -133,14 +133,13 @@ namespace Confuser.Core {
 			Dictionary<string, string> packerParams = null;
 
 			if (proj.Packer != null) {
-				if (!packers.ContainsKey(proj.Packer.Id)) {
+				if (!packers.TryGetValue(proj.Packer.Id, out packer)) {
 					context.Logger.ErrorFormat("Cannot find packer with ID '{0}'.", proj.Packer.Id);
 					throw new ConfuserException(null);
 				}
 				if (proj.Debug)
 					context.Logger.Warn("Generated Debug symbols might not be usable with packers!");
 
-				packer = packers[proj.Packer.Id];
 				packerParams = new Dictionary<string, string>(proj.Packer, StringComparer.OrdinalIgnoreCase);
 			}
 

--- a/Confuser.Core/ModuleSorter.cs
+++ b/Confuser.Core/ModuleSorter.cs
@@ -21,15 +21,15 @@ namespace Confuser.Core {
 			var asmMap = modules.GroupBy(module => module.Assembly.ToAssemblyRef(), AssemblyNameComparer.CompareAll)
 			                    .ToDictionary(gp => gp.Key, gp => gp.ToList(), AssemblyNameComparer.CompareAll);
 
-			foreach (ModuleDefMD m in modules)
-				foreach (AssemblyRef nameRef in m.GetAssemblyRefs()) {
-					if (!asmMap.ContainsKey(nameRef))
-						continue;
-
-					foreach (var asmModule in asmMap[nameRef])
-						edges.Add(new DependencyGraphEdge(asmModule, m));
-					roots.Remove(m);
+			foreach (var m in modules) {
+				foreach (var nameRef in m.GetAssemblyRefs()) {
+					if (asmMap.TryGetValue(nameRef, out var asmModules)) {
+						foreach (var asmModule in asmModules)
+							edges.Add(new DependencyGraphEdge(asmModule, m));
+						roots.Remove(m);
+					}
 				}
+			}
 
 			var sorted = SortGraph(roots, edges).ToList();
 			Debug.Assert(sorted.Count == modules.Count);

--- a/Confuser.Core/ObfAttrMarker.cs
+++ b/Confuser.Core/ObfAttrMarker.cs
@@ -297,12 +297,11 @@ namespace Confuser.Core {
 			extModules = new List<byte[]>();
 
 			if (proj.Packer != null) {
-				if (!packers.ContainsKey(proj.Packer.Id)) {
+				if (!packers.TryGetValue(proj.Packer.Id, out packer)) {
 					context.Logger.ErrorFormat("Cannot find packer with ID '{0}'.", proj.Packer.Id);
 					throw new ConfuserException(null);
 				}
 
-				packer = packers[proj.Packer.Id];
 				packerParams = new Dictionary<string, string>(proj.Packer, StringComparer.OrdinalIgnoreCase);
 			}
 

--- a/Confuser.Core/ObfAttrParser.cs
+++ b/Confuser.Core/ObfAttrParser.cs
@@ -206,16 +206,17 @@ namespace Confuser.Core {
 								throw new KeyNotFoundException("Cannot find protection with id '" + protId + "'.");
 
 							if (protAct) {
-								if (settings.ContainsKey((Protection)items[protId])) {
-									var p = settings[(Protection)items[protId]];
+								if (settings.TryGetValue((Protection)items[protId], out var p)) {
 									foreach (var kvp in protParams)
 										p[kvp.Key] = kvp.Value;
 								}
-								else
+								else {
 									settings[(Protection)items[protId]] = protParams;
+								}
 							}
-							else
+							else {
 								settings.Remove((Protection)items[protId]);
+							}
 						}
 						protParams = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 

--- a/Confuser.Core/Services/TraceService.cs
+++ b/Confuser.Core/Services/TraceService.cs
@@ -90,15 +90,6 @@ namespace Confuser.Core.Services {
 		public int[] AfterStackDepths { get; private set; }
 
 		/// <summary>
-		///     Determines whether the specified instruction is the target of a branch instruction.
-		/// </summary>
-		/// <param name="instrIndex">The index of instruction.</param>
-		/// <returns><c>true</c> if the specified instruction is a branch target; otherwise, <c>false</c>.</returns>
-		public bool IsBranchTarget(int instrIndex) {
-			return fromInstrs.ContainsKey(instrIndex);
-		}
-
-		/// <summary>
 		///     Perform the actual tracing.
 		/// </summary>
 		/// <returns>This instance.</returns>
@@ -238,8 +229,8 @@ namespace Confuser.Core.Services {
 						}
 					}
 
-					if (fromInstrs.ContainsKey(index))
-						foreach (Instruction fromInstr in fromInstrs[index]) {
+					if (fromInstrs.TryGetValue(index, out var instructions))
+						foreach (var fromInstr in instructions) {
 							if (!seen.Contains(fromInstr.Offset)) {
 								seen.Add(fromInstr.Offset);
 								working.Enqueue(offset2index[fromInstr.Offset]);

--- a/Confuser.Core/Utils.cs
+++ b/Confuser.Core/Utils.cs
@@ -189,6 +189,19 @@ namespace Confuser.Core {
 			}
 		}
 
+		public static void RemoveRange<T>(this IList<T> self, int index, int count) {
+			if (self is List<T> list) {
+				list.RemoveRange(index, count);
+				return;
+			}
+
+			for (int i = index + count - 1; i >= index; i--) {
+				self.RemoveAt(i);
+			}
+		}
+
+		public static void RemoveLast<T>(this List<T> self) => self.RemoveAt(self.Count - 1);
+
 		/// <summary>
 		///     Returns a <see cref="IEnumerable{T}" /> that log the progress of iterating the specified list.
 		/// </summary>

--- a/Confuser.Core/Utils.cs
+++ b/Confuser.Core/Utils.cs
@@ -189,6 +189,13 @@ namespace Confuser.Core {
 			}
 		}
 
+		public static int RemoveAndInsertRange<T>(this IList<T> self, int index, int removingCount, IEnumerable<T> collection) {
+			int previousCount = self.Count;
+			self.RemoveRange(index, removingCount);
+			self.InsertRange(index, collection);
+			return self.Count - previousCount;
+		}
+
 		public static void RemoveRange<T>(this IList<T> self, int index, int count) {
 			if (self is List<T> list) {
 				list.RemoveRange(index, count);

--- a/Confuser.Core/Utils.cs
+++ b/Confuser.Core/Utils.cs
@@ -200,6 +200,19 @@ namespace Confuser.Core {
 			}
 		}
 
+		public static void InsertRange<T>(this IList<T> self, int index, IEnumerable<T> collection) {
+			if (self is List<T> list && index < self.Count) {
+				list.InsertRange(index, collection);
+				return;
+			}
+
+			var localIndex = 0;
+			foreach (var element in collection) {
+				self.Insert(index + localIndex, element);
+				localIndex++;
+			}
+		}
+
 		public static void RemoveLast<T>(this List<T> self) => self.RemoveAt(self.Count - 1);
 
 		/// <summary>

--- a/Confuser.DynCipher/Generation/DMCodeGen.cs
+++ b/Confuser.DynCipher/Generation/DMCodeGen.cs
@@ -30,15 +30,15 @@ namespace Confuser.DynCipher.Generation {
 		}
 
 		protected virtual void LoadVar(Variable var) {
-			if (paramMap.ContainsKey(var.Name))
-				ilGen.Emit(OpCodes.Ldarg, paramMap[var.Name]);
+			if (paramMap.TryGetValue(var.Name, out var param))
+				ilGen.Emit(OpCodes.Ldarg, param);
 			else
 				ilGen.Emit(OpCodes.Ldloc, Var(var));
 		}
 
 		protected virtual void StoreVar(Variable var) {
-			if (paramMap.ContainsKey(var.Name))
-				ilGen.Emit(OpCodes.Starg, paramMap[var.Name]);
+			if (paramMap.TryGetValue(var.Name, out var param))
+				ilGen.Emit(OpCodes.Starg, param);
 			else
 				ilGen.Emit(OpCodes.Stloc, Var(var));
 		}

--- a/Confuser.Protections/AntiTamper/AntiMode.cs
+++ b/Confuser.Protections/AntiTamper/AntiMode.cs
@@ -65,9 +65,7 @@ namespace Confuser.Protections.AntiTamper {
 						Instruction ldDst = instrs[i - 2];
 						Instruction ldSrc = instrs[i - 1];
 						Debug.Assert(ldDst.OpCode == OpCodes.Ldloc && ldSrc.OpCode == OpCodes.Ldloc);
-						instrs.RemoveAt(i);
-						instrs.RemoveAt(i - 1);
-						instrs.RemoveAt(i - 2);
+						instrs.RemoveRange(i - 2, 3);
 						instrs.InsertRange(i - 2, deriver.EmitDerivation(initMethod, context, (Local)ldDst.Operand, (Local)ldSrc.Operand));
 					}
 				}

--- a/Confuser.Protections/AntiTamper/JITMode.cs
+++ b/Confuser.Protections/AntiTamper/JITMode.cs
@@ -88,9 +88,7 @@ namespace Confuser.Protections.AntiTamper {
 						Instruction ldDst = instrs[i - 2];
 						Instruction ldSrc = instrs[i - 1];
 						Debug.Assert(ldDst.OpCode == OpCodes.Ldloc && ldSrc.OpCode == OpCodes.Ldloc);
-						instrs.RemoveAt(i);
-						instrs.RemoveAt(i - 1);
-						instrs.RemoveAt(i - 2);
+						instrs.RemoveRange(i - 2, 3);
 						instrs.InsertRange(i - 2, deriver.EmitDerivation(initMethod, context, (Local)ldDst.Operand, (Local)ldSrc.Operand));
 					}
 				}

--- a/Confuser.Protections/AntiTamper/NormalMode.cs
+++ b/Confuser.Protections/AntiTamper/NormalMode.cs
@@ -65,9 +65,7 @@ namespace Confuser.Protections.AntiTamper {
 						Instruction ldDst = instrs[i - 2];
 						Instruction ldSrc = instrs[i - 1];
 						Debug.Assert(ldDst.OpCode == OpCodes.Ldloc && ldSrc.OpCode == OpCodes.Ldloc);
-						instrs.RemoveAt(i);
-						instrs.RemoveAt(i - 1);
-						instrs.RemoveAt(i - 2);
+						instrs.RemoveRange(i - 2, 3);
 						instrs.InsertRange(i - 2, deriver.EmitDerivation(initMethod, context, (Local)ldDst.Operand, (Local)ldSrc.Operand));
 					}
 				}

--- a/Confuser.Protections/AntiTamper/NormalMode.cs
+++ b/Confuser.Protections/AntiTamper/NormalMode.cs
@@ -48,31 +48,34 @@ namespace Confuser.Protections.AntiTamper {
 
 			var rt = context.Registry.GetService<IRuntimeService>();
 			TypeDef initType = rt.GetRuntimeType("Confuser.Runtime.AntiTamperNormal");
-			IEnumerable<IDnlibDef> members = InjectHelper.Inject(initType, context.CurrentModule.GlobalType, context.CurrentModule);
+			var members = InjectHelper.Inject(initType, context.CurrentModule.GlobalType, context.CurrentModule)
+				.ToArray();
 			var initMethod = (MethodDef)members.Single(m => m.Name == "Initialize");
 
 			initMethod.Body.SimplifyMacros(initMethod.Parameters);
-			List<Instruction> instrs = initMethod.Body.Instructions.ToList();
-			for (int i = 0; i < instrs.Count; i++) {
-				Instruction instr = instrs[i];
-				if (instr.OpCode == OpCodes.Ldtoken) {
-					instr.Operand = context.CurrentModule.GlobalType;
+			var instructions = initMethod.Body.Instructions;
+			int instructionIndex = 0;
+			while (instructionIndex < instructions.Count) {
+				var instruction = instructions[instructionIndex];
+				if (instruction.OpCode == OpCodes.Ldtoken) {
+					instruction.Operand = context.CurrentModule.GlobalType;
 				}
-				else if (instr.OpCode == OpCodes.Call) {
-					var method = (IMethod)instr.Operand;
-					if (method.DeclaringType.Name == "Mutation" &&
-						method.Name == "Crypt") {
-						Instruction ldDst = instrs[i - 2];
-						Instruction ldSrc = instrs[i - 1];
+				else if (instruction.OpCode == OpCodes.Call) {
+					var method = (IMethod)instruction.Operand;
+					if (method.DeclaringType.Name == "Mutation" && method.Name == "Crypt") {
+						var ldDst = instructions[instructionIndex - 2];
+						var ldSrc = instructions[instructionIndex - 1];
 						Debug.Assert(ldDst.OpCode == OpCodes.Ldloc && ldSrc.OpCode == OpCodes.Ldloc);
-						instrs.RemoveRange(i - 2, 3);
-						instrs.InsertRange(i - 2, deriver.EmitDerivation(initMethod, context, (Local)ldDst.Operand, (Local)ldSrc.Operand));
+						instructionIndex += instructions.RemoveAndInsertRange(
+							instructionIndex - 2,
+							3,
+							deriver.EmitDerivation(initMethod, context, (Local)ldDst.Operand, (Local)ldSrc.Operand)
+						);
+						continue;
 					}
 				}
+				instructionIndex++;
 			}
-			initMethod.Body.Instructions.Clear();
-			foreach (Instruction instr in instrs)
-				initMethod.Body.Instructions.Add(instr);
 
 			MutationHelper.InjectKeys(initMethod,
 									  new[] { 0, 1, 2, 3, 4 },

--- a/Confuser.Protections/Compress/Compressor.cs
+++ b/Confuser.Protections/Compress/Compressor.cs
@@ -269,9 +269,7 @@ namespace Confuser.Protections {
 						Instruction ldDst = instrs[i - 2];
 						Instruction ldSrc = instrs[i - 1];
 						Debug.Assert(ldDst.OpCode == OpCodes.Ldloc && ldSrc.OpCode == OpCodes.Ldloc);
-						instrs.RemoveAt(i);
-						instrs.RemoveAt(i - 1);
-						instrs.RemoveAt(i - 2);
+						instrs.RemoveRange(i - 2, 3);
 						instrs.InsertRange(i - 2, compCtx.Deriver.EmitDerivation(decrypter, context, (Local)ldDst.Operand, (Local)ldSrc.Operand));
 					}
 					else if (method.DeclaringType.Name == "Lzma" &&

--- a/Confuser.Protections/Constants/EncodePhase.cs
+++ b/Confuser.Protections/Constants/EncodePhase.cs
@@ -150,7 +150,7 @@ namespace Confuser.Protections.Constants {
 				if (buffIndex + 1 < moduleCtx.EncodedBuffer.Count && moduleCtx.EncodedBuffer[buffIndex + 1] == hi)
 					break;
 			} while (buffIndex >= 0);
-			
+
 			if (buffIndex == -1) {
 				buffIndex = moduleCtx.EncodedBuffer.Count;
 				moduleCtx.EncodedBuffer.Add(lo);
@@ -178,9 +178,7 @@ namespace Confuser.Protections.Constants {
 				instrs[i - 3].OpCode = OpCodes.Call;
 				var arrType = new SZArraySig(((ITypeDefOrRef)instrs[i - 3].Operand).ToTypeSig());
 				instrs[i - 3].Operand = new MethodSpecUser(decoder.Item1, new GenericInstMethodSig(arrType));
-				instrs.RemoveAt(i - 2);
-				instrs.RemoveAt(i - 2);
-				instrs.RemoveAt(i - 2);
+				instrs.RemoveRange(i - 2, 3);
 			}
 		}
 

--- a/Confuser.Protections/Constants/EncodePhase.cs
+++ b/Confuser.Protections/Constants/EncodePhase.cs
@@ -292,8 +292,7 @@ namespace Confuser.Protections.Constants {
 
 							// Prevent array length from being encoded
 							var arrLen = (int)instrs[i - 4].Operand;
-							if (ldc.ContainsKey(arrLen)) {
-								List<Tuple<MethodDef, Instruction>> list = ldc[arrLen];
+							if (ldc.TryGetValue(arrLen, out var list)) {
 								list.RemoveWhere(entry => entry.Item2 == instrs[i - 4]);
 								if (list.Count == 0)
 									ldc.Remove(arrLen);

--- a/Confuser.Protections/Constants/InjectPhase.cs
+++ b/Confuser.Protections/Constants/InjectPhase.cs
@@ -159,10 +159,9 @@ namespace Confuser.Protections.Constants {
 						Instruction ldBlock = instrs[i - 2];
 						Instruction ldKey = instrs[i - 1];
 						Debug.Assert(ldBlock.OpCode == OpCodes.Ldloc && ldKey.OpCode == OpCodes.Ldloc);
-						instrs.RemoveAt(i);
-						instrs.RemoveAt(i - 1);
-						instrs.RemoveAt(i - 2);
-						instrs.InsertRange(i - 2, moduleCtx.ModeHandler.EmitDecrypt(moduleCtx.InitMethod, moduleCtx, (Local)ldBlock.Operand, (Local)ldKey.Operand));
+						instrs.RemoveRange(i - 2, 3);
+						instrs.InsertRange(i - 2, moduleCtx.ModeHandler.EmitDecrypt(moduleCtx.InitMethod, moduleCtx,
+							(Local)ldBlock.Operand, (Local)ldKey.Operand));
 					}
 					else if (method.DeclaringType.Name == "Lzma" &&
 					         method.Name == "Decompress") {

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -316,7 +316,7 @@ namespace Confuser.Protections.ControlFlow {
 								var targetKey = predicate != null ? predicate.GetSwitchKey(brKey) : brKey;
 								var unkSrc = hasUnknownSource(newStatement);
 
-								newStatement.RemoveAt(newStatement.Count - 1);
+								newStatement.RemoveLast();
 
 								if (unkSrc) {
 									newStatement.Add(Instruction.Create(OpCodes.Ldc_I4, targetKey));
@@ -347,7 +347,7 @@ namespace Confuser.Protections.ControlFlow {
 								bool unkSrc = hasUnknownSource(newStatement);
 								int nextKey = key[i + 1];
 								OpCode condBr = newStatement.Last().OpCode;
-								newStatement.RemoveAt(newStatement.Count - 1);
+								newStatement.RemoveLast();
 
 								if (ctx.Random.NextBoolean()) {
 									condBr = InverseBranch(condBr);

--- a/Confuser.Protections/ControlFlow/SwitchMangler.cs
+++ b/Confuser.Protections/ControlFlow/SwitchMangler.cs
@@ -35,12 +35,10 @@ namespace Confuser.Protections.ControlFlow {
 						BeforeStack[eh.FilterStart.Offset] = 1;
 				}
 
-				int currentStack = 0;
 				for (int i = 0; i < body.Instructions.Count; i++) {
 					var instr = body.Instructions[i];
 
-					if (BeforeStack.ContainsKey(instr.Offset))
-						currentStack = BeforeStack[instr.Offset];
+					BeforeStack.TryGetValue(instr.Offset, out int currentStack);
 
 					BeforeStack[instr.Offset] = currentStack;
 					instr.UpdateStack(ref currentStack, hasReturnValue);
@@ -55,12 +53,8 @@ namespace Confuser.Protections.ControlFlow {
 
 							Increment(RefCount, offset);
 							BrRefs.AddListEntry(offset, instr);
-
-							currentStack = 0;
 							continue;
 						case FlowControl.Call:
-							if (instr.OpCode.Code == Code.Jmp)
-								currentStack = 0;
 							break;
 						case FlowControl.Cond_Branch:
 							if (instr.OpCode.Code == Code.Switch) {

--- a/Confuser.Protections/ReferenceProxy/StrongMode.cs
+++ b/Confuser.Protections/ReferenceProxy/StrongMode.cs
@@ -291,7 +291,7 @@ namespace Confuser.Protections.ReferenceProxy {
 				MutationHelper.InjectKeys(injectedMethod, Enumerable.Range(0, 9).ToArray(), keyInjection);
 
 				// Encoding
-				MutationHelper.ReplacePlaceholder(injectedMethod, arg => { return encoding.EmitDecode(injectedMethod, ctx, arg); });
+				MutationHelper.ReplacePlaceholder(injectedMethod, arg => encoding.EmitDecode(injectedMethod, ctx, arg));
 				desc.Encoding = encoding;
 
 				initDescs[index] = desc;
@@ -310,10 +310,12 @@ namespace Confuser.Protections.ReferenceProxy {
 
 				TypeDef delegateType = field.Value.Item1.DeclaringType;
 
-				MethodDef cctor = delegateType.FindOrCreateStaticConstructor();
-				cctor.Body.Instructions.Insert(0, Instruction.Create(OpCodes.Call, init.Method));
-				cctor.Body.Instructions.Insert(0, Instruction.CreateLdcI4(opKey));
-				cctor.Body.Instructions.Insert(0, Instruction.Create(OpCodes.Ldtoken, field.Value.Item1));
+				var cctor = delegateType.FindOrCreateStaticConstructor();
+				cctor.Body.Instructions.InsertRange(0, new [] {
+					Instruction.Create(OpCodes.Ldtoken, field.Value.Item1),
+					Instruction.CreateLdcI4(opKey),
+					Instruction.Create(OpCodes.Call, init.Method)
+				});
 
 				fieldDescs.Add(new FieldDesc {
 					Field = field.Value.Item1,

--- a/Confuser.Protections/Resources/InjectPhase.cs
+++ b/Confuser.Protections/Resources/InjectPhase.cs
@@ -116,9 +116,7 @@ namespace Confuser.Protections.Resources {
 						Instruction ldBlock = instrs[i - 2];
 						Instruction ldKey = instrs[i - 1];
 						Debug.Assert(ldBlock.OpCode == OpCodes.Ldloc && ldKey.OpCode == OpCodes.Ldloc);
-						instrs.RemoveAt(i);
-						instrs.RemoveAt(i - 1);
-						instrs.RemoveAt(i - 2);
+						instrs.RemoveRange(i - 2, 3);
 						instrs.InsertRange(i - 2, moduleCtx.ModeHandler.EmitDecrypt(moduleCtx.InitMethod, moduleCtx, (Local)ldBlock.Operand, (Local)ldKey.Operand));
 					}
 					else if (method.DeclaringType.Name == "Lzma" &&

--- a/Confuser.Protections/TypeScrambler/Scrambler/Rewriter/Instructions/MemberRefInstructionRewriter.cs
+++ b/Confuser.Protections/TypeScrambler/Scrambler/Rewriter/Instructions/MemberRefInstructionRewriter.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using Confuser.Core;
 using dnlib.DotNet;
 using dnlib.DotNet.Emit;
 
@@ -48,8 +49,12 @@ namespace Confuser.Protections.TypeScrambler.Scrambler.Rewriter.Instructions {
 				}
 				body[index].Operand = newTypeSpec;
 
-				body.Insert(++index, Instruction.Create(OpCodes.Call, mod.Import(gettype)));
-				body.Insert(++index, Instruction.Create(OpCodes.Call, mod.Import(createInstance)));
+				var instructions = new[] {
+					Instruction.Create(OpCodes.Call, mod.Import(gettype)),
+					Instruction.Create(OpCodes.Call, mod.Import(createInstance))
+				};
+				body.InsertRange(index + 1, instructions);
+				index += instructions.Length;
 			}
 		}
 	}

--- a/Confuser.Protections/TypeScrambler/TypeService.cs
+++ b/Confuser.Protections/TypeScrambler/TypeService.cs
@@ -19,8 +19,9 @@ namespace Confuser.Protections.TypeScrambler {
 
 		private void AddScannedItemGeneral(ScannedItem m) {
 			m.Scan();
-			if (!GenericsMapper.ContainsKey(m.GetMemberDef())) {
-				GenericsMapper.Add(m.GetMemberDef(), m);
+			var memberDef = m.GetMemberDef();
+			if (!GenericsMapper.ContainsKey(memberDef)) {
+				GenericsMapper.Add(memberDef, m);
 			}
 		}
 

--- a/Confuser.Renamer/VTable.cs
+++ b/Confuser.Renamer/VTable.cs
@@ -156,7 +156,7 @@ namespace Confuser.Renamer {
 					if (slots.Select(g => g.Key)
 						.Any(sig => virtualMethods.ContainsKey(sig) || vTbl.SlotsMap.ContainsKey(sig))) {
 						// Something has a new signature. We need to rewrite the whole thing.
-						
+
 						// This is the step 1 of 12.2 algorithm -- find implementation for still empty slots.
 						// Note that it seems we should include newslot methods as well, despite what the standard said.
 						slots = slots
@@ -214,7 +214,7 @@ namespace Confuser.Renamer {
 						vTbl.InterfaceSlots[iface] = ifaceVTbl
 							.SelectMany(g => g.Select(slot => (g.Key, Slot: slot)))
 							.ToLookup(t => t.Key, t => {
-								if (!t.Key.Equals(signature)) 
+								if (!t.Key.Equals(signature))
 									return t.Slot;
 
 								var targetSlot = t.Slot;
@@ -270,23 +270,22 @@ namespace Confuser.Renamer {
 				return slot;
 			};
 
-			if (vTbl.InterfaceSlots.ContainsKey(iface)) {
-				vTbl.InterfaceSlots[iface] = vTbl.InterfaceSlots[iface].SelectMany(g => g).ToLookup(
+			var interfaceSlots = vTbl.InterfaceSlots;
+			if (interfaceSlots.TryGetValue(iface, out var interfaceSlot)) {
+				interfaceSlots[iface] = interfaceSlot.SelectMany(g => g).ToLookup(
 					slot => slot.Signature, implLookup);
 			}
 			else {
-				vTbl.InterfaceSlots.Add(iface, ifaceVTbl.Slots.ToLookup(
-					slot => slot.Signature, implLookup));
+				interfaceSlots.Add(iface, ifaceVTbl.Slots.ToLookup(slot => slot.Signature, implLookup));
 			}
 
 			foreach (var baseIface in ifaceVTbl.InterfaceSlots) {
-				if (vTbl.InterfaceSlots.ContainsKey(baseIface.Key)) {
-					vTbl.InterfaceSlots[baseIface.Key] = vTbl.InterfaceSlots[baseIface.Key].SelectMany(g => g).ToLookup(
+				if (interfaceSlots.TryGetValue(baseIface.Key, out interfaceSlot)) {
+					interfaceSlots[baseIface.Key] = interfaceSlot.SelectMany(g => g).ToLookup(
 						slot => slot.Signature, implLookup);
 				}
 				else {
-					vTbl.InterfaceSlots.Add(baseIface.Key, baseIface.Value.ToLookup(
-						slot => slot.Signature, implLookup));
+					interfaceSlots.Add(baseIface.Key, baseIface.Value.ToLookup(slot => slot.Signature, implLookup));
 				}
 			}
 		}

--- a/Tests/MessageDeobfuscation.Test/MessageDeobfuscationTest.cs
+++ b/Tests/MessageDeobfuscation.Test/MessageDeobfuscationTest.cs
@@ -47,12 +47,12 @@ namespace MessageDeobfuscation.Test {
 						eventId = "_cbPBZqkDuaNXOkmJtacrG2uYfZs";
 					}
 					else {
-						classId = "_g";
-						nestedClassId = "_e";
-						methodId = "_C";
-						fieldId = "_d";
-						propertyId = "_E";
-						eventId = "_b";
+						classId = "_F";
+						nestedClassId = "_D";
+						methodId = "_c";
+						fieldId = "_C";
+						propertyId = "_e";
+						eventId = "_A";
 					}
 
 					void CheckName(string expectedFullName, string expectedShortName, string obfuscatedName) {
@@ -92,8 +92,8 @@ namespace MessageDeobfuscation.Test {
 				new object[] {
 					nameof(RenameMode.Sequential), new[] {
 						"Exception",
-						"   at _g._e._c(String )",
-						"   at _B._f()"
+						"   at _F._D._B(String )",
+						"   at _b._E()"
 					}
 				}
 			};
@@ -122,8 +122,8 @@ namespace MessageDeobfuscation.Test {
 		public async Task CheckPasswordDependsOnSeed() {
 			var expectedObfuscatedOutput = new[] {
 				"Exception",
-				"   at oZuuchQgRo99FxO43G5kj2LB6aE3b$hsLiIOVL3cn0lg.CN9UQGJKgUbt4OKGBs8_vig.FtV6w7kWA1GcUNTnc2UDptg(String )",
-				"   at EcGxTPKtKIEeZuP3ekjPVhrVKQsiovm5zMkq5xfZbt1V.xvkt0Ir5VfNl8phozRzOvg8()"
+				"   at oZuuchQgRo99FxO43G5kj2LB6aE3b$hsLiIOVL3cn0lg.98C7L64wnMJK6DFKHzyWSw8.at9I2jHJrbSIlewmDrNXdMI(String )",
+				"   at EcGxTPKtKIEeZuP3ekjPVhrVKQsiovm5zMkq5xfZbt1V.AiskF07vqbD8ZFG03Jyiiu8()"
 			};
 			await RunDeobfuscationWithPassword(true, Seed, "_0", expectedObfuscatedOutput,
 				outputPath => {
@@ -143,8 +143,8 @@ namespace MessageDeobfuscation.Test {
 		public async Task MessageDeobfuscationWithPassword() {
 			var expectedObfuscatedOutput = new[] {
 				"Exception",
-				"   at oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8.CE8t0VDPQk9$jgv1XuRwt1k.FhsPrCLqIAaPKe7abGklvY4(String )",
-				"   at EbUjRcrC76NnA7RJlhQffrfp$vMGHdDfqtVFtWrAOPyD.xgIw9voebB21PlxPFA_hs60()"
+				"   at oQmpV$y2k2b9P3d6GP1cxGPuRtKaNIZvZcKpZXSfKFG8.99_z9Rxdp_fWfuD3fr45FSA.at9DaPNMANuLaMV_3scPWDU(String )",
+				"   at EbUjRcrC76NnA7RJlhQffrfp$vMGHdDfqtVFtWrAOPyD.AkpOh$3Zo3M8ga5lTY9etcM()"
 			};
 			await RunDeobfuscationWithPassword(false, null, "", expectedObfuscatedOutput, outputPath => {
 				var deobfuscator = new MessageDeobfuscator(Password);


### PR DESCRIPTION
I've tried to reduce `FindDefinitions` calls in the pipeline and it seems working at least for me.

But more testing would be useful.

Also, I've tried to implement #400 but it's quite complicated because two passes of definitions are required.