### PR TITLE
Copy custom attributes from origin to injected type

### DIFF
--- a/Confuser.Core/Helpers/InjectHelper.cs
+++ b/Confuser.Core/Helpers/InjectHelper.cs
@@ -85,9 +85,9 @@ namespace Confuser.Core.Helpers {
 			var newTypeDef = ctx.Map(typeDef)?.ResolveTypeDefThrow();
 			newTypeDef.BaseType = ctx.Importer.Import(typeDef.BaseType);
 			
-			foreach (var customAttribute in typeDef.CustomAttributes)
-				newTypeDef.CustomAttributes.Add(customAttribute);
-			
+			foreach (CustomAttribute customAttribute in typeDef.CustomAttributes)
+				newTypeDef.CustomAttributes.Add(new CustomAttribute((ICustomAttributeType)ctx.Importer.Import(customAttribute.Constructor)));
+
 			foreach (InterfaceImpl iface in typeDef.Interfaces)
 				newTypeDef.Interfaces.Add(new InterfaceImplUser(ctx.Importer.Import(iface.Interface)));
 		}

--- a/Confuser.Core/Helpers/InjectHelper.cs
+++ b/Confuser.Core/Helpers/InjectHelper.cs
@@ -84,7 +84,10 @@ namespace Confuser.Core.Helpers {
 		static void CopyTypeDef(TypeDef typeDef, InjectContext ctx) {
 			var newTypeDef = ctx.Map(typeDef)?.ResolveTypeDefThrow();
 			newTypeDef.BaseType = ctx.Importer.Import(typeDef.BaseType);
-
+			
+			foreach (var customAttribute in typeDef.CustomAttributes)
+				newTypeDef.CustomAttributes.Add(customAttribute);
+			
 			foreach (InterfaceImpl iface in typeDef.Interfaces)
 				newTypeDef.Interfaces.Add(new InterfaceImplUser(ctx.Importer.Import(iface.Interface)));
 		}


### PR DESCRIPTION
Delegate types require custom attributes to function properly on some occasions.