### PR TITLE
Fix Newtonsoft Serialization

### DIFF
--- a/Confuser.Renamer/Analyzers/JsonAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/JsonAnalyzer.cs
@@ -95,9 +95,9 @@ namespace Confuser.Renamer.Analyzers {
 		}
 
 		void Analyze(ConfuserContext context, INameService service, MethodDef method, ProtectionParameters parameters) {
-			if (GetJsonContainerAttribute(method.DeclaringType) != null && method.IsConstructor) {
+			//if (GetJsonContainerAttribute(method.DeclaringType) != null && method.IsConstructor) {
 				service.SetParam(method, "renameArgs", "false");
-			}
+			//}
 		}
 
 		void Analyze(ConfuserContext context, INameService service, PropertyDef property, ProtectionParameters parameters) {

--- a/Confuser.Renamer/Analyzers/JsonAnalyzer.cs
+++ b/Confuser.Renamer/Analyzers/JsonAnalyzer.cs
@@ -94,10 +94,8 @@ namespace Confuser.Renamer.Analyzers {
 				service.SetCanRename(type, false);
 		}
 
-		void Analyze(ConfuserContext context, INameService service, MethodDef method, ProtectionParameters parameters) {
-			//if (GetJsonContainerAttribute(method.DeclaringType) != null && method.IsConstructor) {
+		void Analyze(ConfuserContext context, INameService service, MethodDef method, ProtectionParameters parameters) {		
 				service.SetParam(method, "renameArgs", "false");
-			//}
 		}
 
 		void Analyze(ConfuserContext context, INameService service, PropertyDef property, ProtectionParameters parameters) {


### PR DESCRIPTION
Do not Rename Arguments, Fixes the error " A member with the name ' ' already exists" 