### PR TITLE
Fixed the Obfuscation Attribute marker

### DIFF
--- a/Confuser.Core/ObfAttrMarker.cs
+++ b/Confuser.Core/ObfAttrMarker.cs
@@ -113,7 +113,8 @@ namespace Confuser.Core {
 						continue;
 
 					if (info.Condition == null && info.Exclude) {
-						if (type == ApplyInfoType.CurrentInfoOnly ||
+						if ((type == ApplyInfoType.ParentInfo && info.ApplyToMember) ||
+							type == ApplyInfoType.CurrentInfoOnly ||
 							(type == ApplyInfoType.CurrentInfoInherits && info.ApplyToMember)) {
 							settings.Clear();
 						}

--- a/Confuser2.sln
+++ b/Confuser2.sln
@@ -143,6 +143,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlockingReferencesHelper", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BlockingReferences.Test", "Tests\BlockingReferences.Test\BlockingReferences.Test.csproj", "{4FB03AD0-96FF-4730-801A-4F997795D920}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "421_NewtonsoftJsonSerialization", "Tests\421_NewtonsoftJsonSerialization\421_NewtonsoftJsonSerialization.csproj", "{4EF73752-78B0-4E0D-A33B-B6637B6C2177}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "421_NewtonsoftJsonSerialization.Test", "Tests\421_NewtonsoftJsonSerialization.Test\421_NewtonsoftJsonSerialization.Test.csproj", "{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -909,6 +913,30 @@ Global
 		{4FB03AD0-96FF-4730-801A-4F997795D920}.Release|x64.Build.0 = Release|Any CPU
 		{4FB03AD0-96FF-4730-801A-4F997795D920}.Release|x86.ActiveCfg = Release|Any CPU
 		{4FB03AD0-96FF-4730-801A-4F997795D920}.Release|x86.Build.0 = Release|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Debug|x64.Build.0 = Debug|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Debug|x86.Build.0 = Debug|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Release|x64.ActiveCfg = Release|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Release|x64.Build.0 = Release|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Release|x86.ActiveCfg = Release|Any CPU
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177}.Release|x86.Build.0 = Release|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Debug|x64.Build.0 = Debug|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Debug|x86.Build.0 = Debug|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Release|x64.ActiveCfg = Release|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Release|x64.Build.0 = Release|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Release|x86.ActiveCfg = Release|Any CPU
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -969,6 +997,8 @@ Global
 		{F602DAFE-E8A2-4CB2-AF0E-656CD357D821} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{9EB8DC3B-60DC-451E-8C18-3D7E38D463FD} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 		{4FB03AD0-96FF-4730-801A-4F997795D920} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{4EF73752-78B0-4E0D-A33B-B6637B6C2177} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
+		{B1CB9A30-FEA6-4467-BEC5-4803CCE9BF78} = {356BDB31-853E-43BB-8F9A-D8AC08F69EBB}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0D937D9E-E04B-4A68-B639-D4260473A388}

--- a/Tests/421_NewtonsoftJsonSerialization.Test/421_NewtonsoftJsonSerialization.Test.csproj
+++ b/Tests/421_NewtonsoftJsonSerialization.Test/421_NewtonsoftJsonSerialization.Test.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <RootNamespace>NewtonsoftJsonSerialization.Test</RootNamespace>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Confuser.UnitTest\Confuser.UnitTest.csproj" />
+    <ProjectReference Include="..\421_NewtonsoftJsonSerialization\421_NewtonsoftJsonSerialization.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/421_NewtonsoftJsonSerialization.Test/NewtonsoftJsonTest.cs
+++ b/Tests/421_NewtonsoftJsonSerialization.Test/NewtonsoftJsonTest.cs
@@ -1,0 +1,29 @@
+using System.Threading.Tasks;
+using Confuser.Core;
+using Confuser.Core.Project;
+using Confuser.UnitTest;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NewtonsoftJsonSerialization.Test {
+	public class NewtonsoftJsonTest : TestBase {
+		public NewtonsoftJsonTest(ITestOutputHelper outputHelper) : base(outputHelper) { }
+
+		[Fact]
+		[Trait("Category", "Protection")]
+		[Trait("Protection", "rename")]
+		[Trait("Issue", "https://github.com/mkaring/ConfuserEx/issues/421")]
+		public async Task SignatureMismatch() =>
+			await Run(
+				new[] {
+					"421_NewtonsoftJsonSerialization.exe",
+					"external:Newtonsoft.Json.dll"
+				},
+				new [] {
+					"{\"a\":\"a\",\"b\":\"b\",\"c\":\"c\"}",
+					"{\"a\":\"a\",\"b\":\"b\",\"c\":\"c\"}"
+				},
+				new SettingItem<Protection>("rename")
+			);
+	}
+}

--- a/Tests/421_NewtonsoftJsonSerialization/421_NewtonsoftJsonSerialization.csproj
+++ b/Tests/421_NewtonsoftJsonSerialization/421_NewtonsoftJsonSerialization.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net461</TargetFramework>
+    <RootNamespace>NewtonsoftJsonSerialization</RootNamespace>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Tests/421_NewtonsoftJsonSerialization/ObfExcluded.cs
+++ b/Tests/421_NewtonsoftJsonSerialization/ObfExcluded.cs
@@ -1,0 +1,21 @@
+﻿using System.Reflection;
+using Newtonsoft.Json;
+
+namespace NewtonsoftJsonSerialization {
+	[Obfuscation(Exclude = true)]
+	internal class ObfExcluded {
+		[JsonProperty("a")] public string a;
+
+		[JsonProperty("b")] public string b;
+
+		[JsonProperty("c")] public string c;
+
+		public ObfExcluded(string a, string b, string c) {
+			this.a = a;
+			this.b = b;
+			this.c = c;
+		}
+
+		public override string ToString() => JsonConvert.SerializeObject(this);
+	}
+}

--- a/Tests/421_NewtonsoftJsonSerialization/ObfMarkedWithAttribute.cs
+++ b/Tests/421_NewtonsoftJsonSerialization/ObfMarkedWithAttribute.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace NewtonsoftJsonSerialization {
+	[JsonObject]
+	internal class ObfMarkedWithAttribute {
+		[JsonProperty("a")] public string a;
+
+		[JsonProperty("b")] public string b;
+
+		[JsonProperty("c")] public string c;
+
+		public ObfMarkedWithAttribute(string a, string b, string c) {
+			this.a = a;
+			this.b = b;
+			this.c = c;
+		}
+
+		public override string ToString() => JsonConvert.SerializeObject(this);
+	}
+}

--- a/Tests/421_NewtonsoftJsonSerialization/Program.cs
+++ b/Tests/421_NewtonsoftJsonSerialization/Program.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace NewtonsoftJsonSerialization {
+	class Program {
+		static int Main(string[] args) {
+			Console.WriteLine("START");
+
+			Console.WriteLine(new ObfMarkedWithAttribute("a", "b", "c").ToString());
+			Console.WriteLine(new ObfExcluded("a", "b", "c").ToString());
+
+			Console.WriteLine("END");
+
+			return 42;
+		}
+	}
+}


### PR DESCRIPTION
The marker did not correctly handle the inheritance ob the obfuscation attribute.
This results in members not being excluded correctly, when the attribute asks to do that.

fixes #421