### PR TITLE
Added batch modules loading using a wildcard

### DIFF
--- a/Confuser.CLI/Program.cs
+++ b/Confuser.CLI/Program.cs
@@ -60,8 +60,7 @@ namespace Confuser.CLI {
 					try {
 						var xmlDoc = new XmlDocument();
 						xmlDoc.Load(files[0]);
-						proj.Load(xmlDoc);
-						proj.BaseDirectory = Path.Combine(Path.GetDirectoryName(files[0]), proj.BaseDirectory);
+						proj.Load(xmlDoc, Path.GetDirectoryName(files[0]));
 					}
 					catch (Exception ex) {
 						WriteLineWithColor(ConsoleColor.Red, "Failed to load project:");

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -700,7 +700,7 @@ namespace Confuser.Core.Project {
 
 		internal bool BatchLoadModules(XmlElement elem) {
 			string wildCardPath = elem.Attributes["path"].Value;
-			string[] files = Directory.GetFiles(BaseDirectory, wildCardPath, SearchOption.AllDirectories); // TODO: recursive
+			string[] files = Directory.GetFiles(BaseDirectory, wildCardPath, SearchOption.TopDirectoryOnly);
 			if (files.Length <= 0)
 			{
 				return false;

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -642,7 +642,7 @@ namespace Confuser.Core.Project {
 			OutputDirectory = docElem.Attributes["outputDir"].Value;
 			BaseDirectory = docElem.Attributes["baseDir"].Value;
 			if (!string.IsNullOrEmpty(baseDirRoot))
-            {
+			{
 				BaseDirectory = Path.Combine(baseDirRoot, BaseDirectory);
 			}
 
@@ -702,7 +702,7 @@ namespace Confuser.Core.Project {
 			string wildCardPath = elem.Attributes["path"].Value;
 			string[] files = Directory.GetFiles(BaseDirectory, wildCardPath, SearchOption.AllDirectories); // TODO: recursive
 			if (files.Length <= 0)
-            {
+			{
 				return false;
 			}
 

--- a/Confuser.Core/Project/ConfuserProject.cs
+++ b/Confuser.Core/Project/ConfuserProject.cs
@@ -626,7 +626,7 @@ namespace Confuser.Core.Project {
 		/// <exception cref="Confuser.Core.Project.ProjectValidationException">
 		///     The project XML contains schema errors.
 		/// </exception>
-		public void Load(XmlDocument doc) {
+		public void Load(XmlDocument doc, string baseDirRoot = null) {
 			doc.Schemas.Add(Schema);
 			var exceptions = new List<XmlSchemaException>();
 			doc.Validate((sender, e) => {
@@ -641,6 +641,10 @@ namespace Confuser.Core.Project {
 
 			OutputDirectory = docElem.Attributes["outputDir"].Value;
 			BaseDirectory = docElem.Attributes["baseDir"].Value;
+			if (!string.IsNullOrEmpty(baseDirRoot))
+            {
+				BaseDirectory = Path.Combine(baseDirRoot, BaseDirectory);
+			}
 
 			if (docElem.Attributes["seed"] != null)
 				Seed = docElem.Attributes["seed"].Value.NullIfEmpty();
@@ -674,13 +678,45 @@ namespace Confuser.Core.Project {
 					PluginPaths.Add(i.InnerText);
 				}
 				else {
-					var asm = new ProjectModule();
-					asm.Load(i);
-					Add(asm);
+					AddModule(i);
 				}
 			}
 		}
 
+		internal void AddModule(XmlElement elem) {
+			if (IsWildcard(elem.Attributes["path"].Value)) {
+				BatchLoadModules(elem);
+			}
+			else {
+				var asm = new ProjectModule();
+				asm.Load(elem);
+				Add(asm);
+			}
+		}
+
+		internal bool IsWildcard(string path) {
+			return !string.IsNullOrEmpty(path) && path.Contains(@"*");
+		}
+
+		internal bool BatchLoadModules(XmlElement elem) {
+			string wildCardPath = elem.Attributes["path"].Value;
+			string[] files = Directory.GetFiles(BaseDirectory, wildCardPath, SearchOption.AllDirectories); // TODO: recursive
+			if (files.Length <= 0)
+            {
+				return false;
+			}
+
+			var asmPrototype = new ProjectModule();
+			asmPrototype.Load(elem);
+
+			foreach (string fileName in files) {
+				var moduleEntry = asmPrototype.Clone();
+				moduleEntry.Path = fileName;
+				Add(moduleEntry);
+			}
+
+			return true;
+		}
 		/// <summary>
 		///     Clones this instance.
 		/// </summary>


### PR DESCRIPTION
The change allows using a wildcard to batch load modules that need to be obfuscated. 
Usage example:

```
	<module path="*.dll"                                         >
	    <rule preset="none" pattern="true" inherit="false">
			<protection id="ctrl flow" />
			<protection id="invalid metadata" />
			<protection id="ref proxy" />
			<protection id="rename" />
			<protection id="resources" />
		</rule>
	</module>
```
@mkaring what do you think?