### PR TITLE
Update ConfuserEngine.cs - Do not create debug files when debug=false

### DIFF
--- a/Confuser.Core/ConfuserEngine.cs
+++ b/Confuser.Core/ConfuserEngine.cs
@@ -421,6 +421,8 @@ namespace Confuser.Core {
 
 		static void Debug(ConfuserContext context) {
 			context.Logger.Info("Finalizing...");
+			if(!context.Project.Debug)
+				return;
 			for (int i = 0; i < context.OutputModules.Count; i++) {
 				if (context.OutputSymbols[i] == null)
 					continue;


### PR DESCRIPTION
Confuser does write debug files (.pdb) even if debug=false in project file.